### PR TITLE
Add drivers support

### DIFF
--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -46,6 +46,7 @@ modules:
           - name: jboss.container.wildfly.base
           # s2i dependens on galleon module that installs descriptions and feature-pack sources for modules to add content to dedicated packages
           - name: jboss.container.wildfly.s2i.bash
+          - name: jboss.container.wildfly.s2i.install-common
           # Modules that add runtime scripts to JBOSS_HOME or as custom galleon package
           - name: jboss.container.wildfly.jolokia
           - name: jboss.container.wildfly.datasources-launch


### PR DESCRIPTION
Enable uses of a common module for S2I which adds the ability to use Drivers via CLI

It requires: https://github.com/wildfly/wildfly-cekit-modules/pull/3/files