### PR TITLE
Add jboss.container.wildfly.launch.https to image.yaml

### DIFF
--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -57,6 +57,7 @@ modules:
           - name: jboss.container.wildfly.launch.os.node-name
           - name: jboss.container.wildfly.launch-config.config
           - name: jboss.container.wildfly.launch-config.os
+          - name: jboss.container.wildfly.launch.https
           - name: jboss.container.wildfly.startup
           # At this point, all scripts must have been added to JBOSS_HOME and to custom galleon packages location
           - name: jboss.container.wildfly.galleon.build-feature-pack


### PR DESCRIPTION
Add a module for https legacy configuration

Requires: https://github.com/wildfly/wildfly-cekit-modules/pull/26