### PR TITLE
call CONFIG_ADJUSTMENT_MODE in assemble

### DIFF
--- a/wildfly-modules/jboss/container/wildfly/s2i-wildfly/bash/artifacts/usr/local/s2i/assemble
+++ b/wildfly-modules/jboss/container/wildfly/s2i-wildfly/bash/artifacts/usr/local/s2i/assemble
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+export CONFIG_ADJUSTMENT_MODE=cli
+
 . "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/assemble.sh"

--- a/wildfly-modules/jboss/container/wildfly/startup/artifacts/bin/launch/launch-config.sh
+++ b/wildfly-modules/jboss/container/wildfly/startup/artifacts/bin/launch/launch-config.sh
@@ -27,7 +27,7 @@ CONFIG_SCRIPT_CANDIDATES=(
   $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
 )
 
-# Notice that the value of this variable must be aligned with the value configured in s2i-core-hooks
+# Notice that the value of this variable must be aligned with the value configured in assemble
 export CONFIG_ADJUSTMENT_MODE="cli"
 if [ -z "${DISABLE_GENERATE_DEFAULT_DATASOURCE}" ] ; then
   DISABLE_GENERATE_DEFAULT_DATASOURCE=true


### PR DESCRIPTION
needed because default s2i-core-hooks doesn't do it anymore.