### PR TITLE
Upgrade to galeon 4.2.4, ignore layer exclude from default config. Added test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ file inside your source code repository.
     Can't be used when `GALLEON_PROVISION_LAYERS` is used.
 
 * `GALLEON_PROVISION_LAYERS`
-    A comma separated list of layer names to compose a WildFly server. Any layer name starting with `-` (eg:`-jpa`) will be excluded from the provisioning. Can't be used when `GALLEON_PROVISION_SERVER` is used.
+    A comma separated list of layer names to compose a WildFly server. Any layer name 
+    starting with `-` (eg:`-jpa`) will be excluded from the provisioning. Exclusion of layer can also be specified in 
+    [galleon/provisioning.xml](test/test-app-jaxrs-exclude/galleon/provisioning.xml) file. Can't be used when `GALLEON_PROVISION_SERVER` is used.
 
     * Openshift Base layers:
 

--- a/test/test-app-jaxrs-exclude/galleon/provisioning.xml
+++ b/test/test-app-jaxrs-exclude/galleon/provisioning.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
+         that takes hour instead of returning 404, version is not needed -->
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#19.0.0.Final">
+        <default-configs inherit="false"/>
+        <packages inherit="false"/>
+    </feature-pack>
+    <config model="standalone" name="standalone.xml">
+        <layers>
+            <include name="jaxrs-server"/>
+            <include name="observability"/>
+            <exclude name="open-tracing"/>
+        </layers>
+    </config>
+    <options>
+        <option name="optional-packages" value="passive+"/>
+    </options>
+</installation>

--- a/test/test-app-jaxrs-exclude/pom.xml
+++ b/test/test-app-jaxrs-exclude/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>openshift-demo</groupId>
+    <artifactId>demo-jaxrs</artifactId>
+    <packaging>war</packaging>
+    <version>1.0</version>
+    <name>OpenshiftDemo</name>
+    
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+  
+    <description>This project demonstrates how to implement a JAX-RS service</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <!-- Import the JAX-RS API, we use provided scope as the API is included in JBoss EAP -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+            <version>1.0.1.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- When built in OpenShift the 'openshift' profile will be used when invoking mvn. -->
+            <!-- Use this profile for any OpenShift specific customization your app will need. -->
+            <!-- By default that is to put the resulting archive into the 'deployments' folder. -->
+            <!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
+            <id>openshift</id>
+            <build>
+                <finalName>DemoApp</finalName>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>2.3</version>
+                        <configuration>
+                            <failOnMissingWebXml>false</failOnMissingWebXml>
+                            <outputDirectory>target</outputDirectory>
+                            <warName>ROOT</warName>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/test/test-app-jaxrs-exclude/src/main/java/org/jboss/galleon/demo/Message.java
+++ b/test/test-app-jaxrs-exclude/src/main/java/org/jboss/galleon/demo/Message.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.demo;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class Message {
+    public String getResource() {
+        return "JAXRS resource";
+    }
+    public String getServer() {
+        return "WildFly provisioned with Galleon jaxrs layer";
+    }
+}

--- a/test/test-app-jaxrs-exclude/src/main/java/org/jboss/galleon/demo/Resource.java
+++ b/test/test-app-jaxrs-exclude/src/main/java/org/jboss/galleon/demo/Resource.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.demo;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * A JAX-RS resource for exposing REST endpoint.
+ */
+@Path("/")
+public class Resource {
+
+    @GET
+    @Produces({"application/json"})
+    public Message getMessage() {
+        return new Message();
+    }
+}

--- a/test/test-app-jaxrs-exclude/src/main/webapp/WEB-INF/web.xml
+++ b/test/test-app-jaxrs-exclude/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,25 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+    <!-- One of the way of activating REST Services is adding these lines, the server is responsible for adding the corresponding servlet automatically. If the src folder, org.jboss.as.quickstarts.rshelloworld.HelloWorld class has the Annotations to receive REST invocation-->
+    <servlet-mapping>
+        <servlet-name>javax.ws.rs.core.Application</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -7,7 +7,9 @@
         <!-- to call CLI with runtime scripts -->
         <include name="core-tools"/>
         <!-- we already have all required in default config -->
-        <exclude name="operator-required"/>
+        <!-- Although logically correct, galleon doesn't actually support excluding from model -->
+        <!-- This is harmeless, keeping the exclusion commented for reference until GAL-308 is fixed -->
+        <!--<exclude name="operator-required"/>-->
     </layers>
     <!-- remove opentracing extension and subsystem -->
     <exclude spec="subsystem.microprofile-opentracing-smallrye"/>

--- a/wildfly-modules/tests/features/s2i.feature
+++ b/wildfly-modules/tests/features/s2i.feature
@@ -147,6 +147,7 @@ Feature: Wildfly s2i tests
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS             | jaxrs-server,-foo |
 
+  @ignore # Until cloud-server depends on jaxrs-server (requires upgrade to WF19 beta2)
   Scenario: Test cloud-server, exclude datasources and jpa
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-jaxrs with env and True using master
       | variable                             | value         |


### PR DESCRIPTION
Test Test jaxrs-server+observability, exclude open-tracing from provisioning.xml expected to fail until this PR is merged. We are adding new test app.