### PR TITLE
[CLOUD-3537] Remove the requirement for adding the log manager and it…

### DIFF
--- a/wildfly-modules/jboss/container/wildfly/startup/artifacts/bin/launch/launch-config.sh
+++ b/wildfly-modules/jboss/container/wildfly/startup/artifacts/bin/launch/launch-config.sh
@@ -26,7 +26,6 @@ CONFIG_SCRIPT_CANDIDATES=(
   $JBOSS_HOME/bin/launch/resource-adapter.sh
   $JBOSS_HOME/bin/launch/tracing.sh
   /opt/run-java/proxy-options
-  $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
   $JBOSS_HOME/bin/launch/statefulset.sh
 )
 


### PR DESCRIPTION
…'s dependencies to the boot class path. This will be fixed via WFCORE-4748.

https://issues.redhat.com/browse/CLOUD-3537

This will not work until [WFCORE-4674](https://issues.redhat.com/browse/WFCORE-4674) is resolved and WildFly 21 is released. If this shouldn't remain in the queue until then please feel free to close this.