### PR TITLE
Upgrade to Wildfly 20

### DIFF
--- a/test/test-app-custom/galleon/provisioning.xml
+++ b/test/test-app-custom/galleon/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#19.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#20.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-jaxrs-exclude/galleon/provisioning.xml
+++ b/test/test-app-jaxrs-exclude/galleon/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#19.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#20.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-jaxrs-slim/galleon/provisioning.xml
+++ b/test/test-app-jaxrs-slim/galleon/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#19.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#20.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-jaxrs/galleon/provisioning.xml
+++ b/test/test-app-jaxrs/galleon/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <transitive>
-        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#19.0.0.Final">
+        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#20.0.0.Final">
             <default-configs inherit="false"/>
             <packages inherit="false">
                 <exclude name="org.jboss.resteasy.resteasy-multipart-provider"/>
@@ -21,7 +21,7 @@
     </transitive>
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#19.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#20.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-share-galleon-artifacts/pom.xml
+++ b/test/test-app-share-galleon-artifacts/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-galleon-pack</artifactId>
-            <version>19.0.0.Final</version>
+            <version>20.0.0.Final</version>
             <type>zip</type>
         </dependency>
 

--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -12,7 +12,7 @@ labels:
     - name: io.openshift.expose-services
       value: "8080:http,8778:jolokia"
     - name: io.openshift.tags
-      value: "builder,wildfly,wildfly19"
+      value: "builder,wildfly,wildfly20"
     - name: maintainer
       value: "Jean-François Denise <jdenise@redhat.com>"
 envs:

--- a/wildfly-modules/jboss/container/wildfly/base/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/base/module.yaml
@@ -5,7 +5,7 @@ description: Module to setup WildFly env
 
 envs:
 - name: "WILDFLY_VERSION"
-  value: "19.0.0.Final"
+  value: "20.0.0.Final"
 
 modules:
   install:

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/fat-default-server/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/fat-default-server/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#19.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#20.0.0.Final">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/full-profile/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/full-profile/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <transitive>
-        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#19.0.0.Final">
+        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#20.0.0.Final">
             <default-configs inherit="true"/>
         </feature-pack>
     </transitive>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/slim-default-server/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/slim-default-server/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#19.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#20.0.0.Final">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/standalone-profile/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/standalone-profile/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <transitive>
-        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#19.0.0.Final">
+        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#20.0.0.Final">
             <default-configs inherit="false">
                 <include model="standalone" name="standalone.xml"/>
             </default-configs>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/pom.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wildfly.galleon.s2i</groupId>
     <artifactId>wildfly-s2i-galleon-pack</artifactId>
-    <version>19.0.0.Final</version>
+    <version>20.0.0.Final</version>
     <packaging>pom</packaging>
     <name>WildFly Galleon feature-pack for OpenShift</name>
   

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
@@ -5,9 +5,9 @@ description: Install Galleon descriptions and Wildfly s2i feature-pack. Configur
 
 envs:
 - name: S2I_FP_VERSION
-  value: "19.0.0.Final"
+  value: "20.0.0.Final"
 - name: WILDFLY_EXTRAS_DS_VERSION
-  value: "1.0.7.Final"      
+  value: "1.0.8.Final"      
 - name: GALLEON_DEFINITIONS
   value: /opt/jboss/container/wildfly/galleon/definitions
 - name: GALLEON_DEFAULT_SERVER

--- a/wildfly-modules/jboss/container/wildfly/keycloak/configure.sh
+++ b/wildfly-modules/jboss/container/wildfly/keycloak/configure.sh
@@ -4,8 +4,8 @@ SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
 
-unzip -o $SOURCES_DIR/keycloak-wildfly-adapter-dist-8.0.0.zip -d $JBOSS_HOME
-unzip -o $SOURCES_DIR/keycloak-saml-wildfly-adapter-dist-8.0.0.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/keycloak-wildfly-adapter-dist-10.0.2.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/keycloak-saml-wildfly-adapter-dist-10.0.2.zip -d $JBOSS_HOME
 
 chown -R jboss:root $JBOSS_HOME
 chmod -R g+rwX $JBOSS_HOME

--- a/wildfly-modules/jboss/container/wildfly/keycloak/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/keycloak/module.yaml
@@ -8,9 +8,9 @@ execute:
   user: 185
   
 artifacts:
-- name: keycloak-wildfly-adapter-dist-8.0.0
-  target: keycloak-wildfly-adapter-dist-8.0.0.zip
-  url: https://downloads.jboss.org/keycloak/8.0.0/adapters/keycloak-oidc/keycloak-wildfly-adapter-dist-8.0.0.zip
-- name: keycloak-saml-wildfly-adapter-dist-8.0.0
-  target: keycloak-saml-wildfly-adapter-dist-8.0.0.zip
-  url: https://downloads.jboss.org/keycloak/8.0.0/adapters/saml/keycloak-saml-wildfly-adapter-dist-8.0.0.zip
+- name: keycloak-wildfly-adapter-dist-10.0.2
+  target: keycloak-wildfly-adapter-dist-10.0.2.zip
+  url: https://downloads.jboss.org/keycloak/10.0.2/adapters/keycloak-oidc/keycloak-wildfly-adapter-dist-10.0.2.zip
+- name: keycloak-saml-wildfly-adapter-dist-10.0.2
+  target: keycloak-saml-wildfly-adapter-dist-10.0.2.zip
+  url: https://downloads.jboss.org/keycloak/10.0.2/adapters/saml/keycloak-saml-wildfly-adapter-dist-10.0.2.zip

--- a/wildfly-modules/tests/features/s2i.feature
+++ b/wildfly-modules/tests/features/s2i.feature
@@ -147,7 +147,6 @@ Feature: Wildfly s2i tests
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS             | jaxrs-server,-foo |
 
-  @ignore # Until cloud-server depends on jaxrs-server (requires upgrade to WF19 beta2)
   Scenario: Test cloud-server, exclude datasources and jpa
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-jaxrs with env and True using master
       | variable                             | value         |

--- a/wildfly-runtime-image/image.yaml
+++ b/wildfly-runtime-image/image.yaml
@@ -8,7 +8,7 @@ labels:
     - name: io.openshift.expose-services
       value: "8080:http,8778:jolokia"
     - name: io.openshift.tags
-      value: "wildfly,wildfly19"
+      value: "wildfly,wildfly20"
     - name: maintainer
       value: "Jean-François Denise <jdenise@redhat.com>"
 envs:


### PR DESCRIPTION
* Wildfly Upgrade (https://github.com/wildfly/wildfly-s2i/issues/104)
* Un-ignore a test that is now passing.
* Upgrade to latest keycloak. (https://github.com/wildfly/wildfly-s2i/issues/105)

The failing tests are expected. Some test applications express a dependency on Wildfly 19 in master branch. This PR update them to WildFly 20.
