### PR TITLE
[CLOUD-3470] Add ejb and jpa 2lc test applications

### DIFF
--- a/test/test-app-ejb/pom.xml
+++ b/test/test-app-ejb/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>openshift-test-examples</groupId>
+    <artifactId>test-app-ejb</artifactId>
+    <version>1.0</version>
+    <packaging>war</packaging>
+    <name>test-app-ejb</name>
+    <description>Example application that tests EJBs via JAX-RS resource</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <jakarta.jakartaee-api.version>8.0.0</jakarta.jakartaee-api.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakarta.jakartaee-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>test-app-ejb</finalName>
+    </build>
+
+</project>

--- a/test/test-app-ejb/src/main/java/org/jboss/test/ejb/JAXRSConfig.java
+++ b/test/test-app-ejb/src/main/java/org/jboss/test/ejb/JAXRSConfig.java
@@ -1,0 +1,11 @@
+package org.jboss.test.ejb;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+@ApplicationPath("/")
+public class JAXRSConfig extends Application {
+}

--- a/test/test-app-ejb/src/main/java/org/jboss/test/ejb/RestResource.java
+++ b/test/test-app-ejb/src/main/java/org/jboss/test/ejb/RestResource.java
@@ -1,0 +1,36 @@
+package org.jboss.test.ejb;
+
+import java.io.Serializable;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+@Path("/")
+@SessionScoped
+@Produces(MediaType.TEXT_PLAIN)
+public class RestResource implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    StatefulSessionBean sfsb;
+
+    @GET
+    @Path("/")
+    public String availability() {
+        return "OK";
+    }
+
+    @GET
+    @Path("/messages/{message}")
+    public String createNew(@PathParam(value = "message") String message) {
+        return sfsb.getMessage(message);
+    }
+}

--- a/test/test-app-ejb/src/main/java/org/jboss/test/ejb/StatefulSessionBean.java
+++ b/test/test-app-ejb/src/main/java/org/jboss/test/ejb/StatefulSessionBean.java
@@ -1,0 +1,17 @@
+package org.jboss.test.ejb;
+
+import java.io.Serializable;
+
+import javax.ejb.Stateful;
+
+/**
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+@Stateful
+public class StatefulSessionBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String getMessage(String message) {
+        return "sfsb_"+message;
+    }
+}

--- a/test/test-app-ejb/src/main/webapp/WEB-INF/beans.xml
+++ b/test/test-app-ejb/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/test/test-app-jpa2lc/pom.xml
+++ b/test/test-app-jpa2lc/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>openshift-test-examples</groupId>
+    <artifactId>test-app-jpa2lc</artifactId>
+    <version>1.0</version>
+    <packaging>war</packaging>
+    <name>test-app-jpa2lc</name>
+    <description>Example application that tests via JAXRS resource a JPA second level cache</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <jakarta.jakartaee-api.version>8.0.0</jakarta.jakartaee-api.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakarta.jakartaee-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>test-app-jpa2lc</finalName>
+    </build>
+
+</project>

--- a/test/test-app-jpa2lc/src/main/java/org/jboss/test/jpa2lc/DummyEntity.java
+++ b/test/test-app-jpa2lc/src/main/java/org/jboss/test/jpa2lc/DummyEntity.java
@@ -1,0 +1,34 @@
+package org.jboss.test.jpa2lc;
+
+import java.io.Serializable;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+@Entity
+@Cacheable
+public class DummyEntity implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "DummyEntity{" +
+                "id=" + id +
+                '}';
+    }
+}

--- a/test/test-app-jpa2lc/src/main/java/org/jboss/test/jpa2lc/JAXRSConfig.java
+++ b/test/test-app-jpa2lc/src/main/java/org/jboss/test/jpa2lc/JAXRSConfig.java
@@ -1,0 +1,11 @@
+package org.jboss.test.jpa2lc;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+@ApplicationPath("/")
+public class JAXRSConfig extends Application {
+}

--- a/test/test-app-jpa2lc/src/main/java/org/jboss/test/jpa2lc/RestResource.java
+++ b/test/test-app-jpa2lc/src/main/java/org/jboss/test/jpa2lc/RestResource.java
@@ -1,0 +1,69 @@
+package org.jboss.test.jpa2lc;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.UserTransaction;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:yborgess@redhat.com">Yeray Borges</a>
+ */
+@Path("/")
+@RequestScoped
+@Produces(MediaType.TEXT_PLAIN)
+public class RestResource {
+
+    @PersistenceContext(unitName = "MainPU")
+    private EntityManager em;
+
+    @Inject
+    private UserTransaction tx;
+
+    @GET
+    @Path("/")
+    public String availability() {
+        return "OK";
+    }
+
+    @GET
+    @Path("/create/{id}")
+    public String createNew(@PathParam(value = "id") Long id) throws Exception {
+        final DummyEntity entity = new DummyEntity();
+        entity.setId(id);
+        tx.begin();
+        em.persist(entity);
+        tx.commit();
+
+        return String.format("%d created", id);
+    }
+
+    @GET
+    @Path("/cache/{id}")
+    public String addToCacheByQuerying(@PathParam(value = "id") Long id) {
+        DummyEntity result = em.createQuery("select b from DummyEntity b where b.id=:id", DummyEntity.class)
+                .setParameter("id", id)
+                .getSingleResult();
+
+        return String.format("%d found", result.getId());
+    }
+
+    @GET
+    @Path("/evict/{id}")
+    public String evict(@PathParam(value = "id") Long id) {
+        em.getEntityManagerFactory().getCache().evict(DummyEntity.class, id);
+
+        return String.format("%d evicted", id);
+    }
+
+    @GET
+    @Path("/isInCache/{id}")
+    public boolean isEntityInCache(@PathParam(value = "id") Long id) {
+        return em.getEntityManagerFactory().getCache().contains(DummyEntity.class, id);
+    }
+}

--- a/test/test-app-jpa2lc/src/main/resources/META-INF/persistence.xml
+++ b/test/test-app-jpa2lc/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    <persistence-unit name="MainPU">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <shared-cache-mode>ALL</shared-cache-mode>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.cache.use_second_level_cache" value="true"/>
+            <property name="hibernate.cache.use_query_cache" value="true"/>
+            <property name="hibernate.cache.infinispan.entity.cfg" value="timestamps"/>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/test/test-app-jpa2lc/src/main/webapp/WEB-INF/beans.xml
+++ b/test/test-app-jpa2lc/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>


### PR DESCRIPTION
This commit only includes the tests application that will be later used on the behave tests. We need the tests applications merged to be able to run the CI jobs on a followup PR.

Jira issue: https://issues.redhat.com/browse/CLOUD-3470
Requires: wildfly/wildfly-cekit-modules#208