### PR TITLE
Fix for #130, Add labels to advertise deployments directory

### DIFF
--- a/wildfly-runtime-image/image.yaml
+++ b/wildfly-runtime-image/image.yaml
@@ -11,6 +11,8 @@ labels:
       value: "wildfly,wildfly20"
     - name: maintainer
       value: "Jean-François Denise <jdenise@redhat.com>"
+    - name: "org.jboss.deployments-dir"
+      value: "/opt/wildfly/standalone/deployments"
 envs:
     - name: SCRIPT_DEBUG
       description: If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.


### PR DESCRIPTION
Some tooling can rely on it to discover the wildfly deployments dir.