### PR TITLE
Fix for Issue #133, Behave tests that directly access to wildfly-galleon-pack are failing

### DIFF
--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
@@ -25,11 +25,6 @@ envs:
   value: "/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack"
 - name: GALLEON_FP_COMMON_PKG_NAME
   value: "wildfly.s2i.common"
-# The active profiles are jboss-community-repository and securecentral
-- name: GALLEON_BUILD_FP_MAVEN_ARGS_APPEND
-  value: &mvnArgs "-Dcom.redhat.xpaas.repo.jbossorg"
-- name: GALLEON_PROVISON_FP_MAVEN_ARGS_APPEND
-  value: *mvnArgs
 - name: GALLEON_S2I_FP_GROUP_ID
   value: org.wildfly.galleon.s2i
 - name: GALLEON_S2I_FP_ARTIFACT_ID

--- a/wildfly-modules/tests/features/s2i.feature
+++ b/wildfly-modules/tests/features/s2i.feature
@@ -294,28 +294,52 @@ Feature: Wildfly s2i tests
     Then container log should contain WFLYSRV0025
     And s2i build log should not contain Downloaded
 
- #CLOUD-3866
-  @ignore
+ # We need the nexus maven repo to resolve some artifacts of the old WildFly release that is not present 
+ # in the builder image but referenced in custom provisioning.xml.
+ # That is for test only, completely unrealistic use-case but allows us to control what is downloaded or not during provisioning.
+
   Scenario: Test galleon and app build, download of artifacts
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-galleon-incremental
+    | variable                                      | value         |
+    | MAVEN_REPOS                          | NEXUS  |
+    | NEXUS_MAVEN_REPO_ID         | nexus-jboss |
+    | NEXUS_MAVEN_REPO_NAME   | nexus-jboss  |
+    | NEXUS_MAVEN_REPO_RELEASES_UPDATE_POLICY | never |
+    | NEXUS_MAVEN_REPO_SNAPSHOTS_ENABLED | false |
+    | NEXUS_MAVEN_REPO_URL      | https://repository.jboss.org/nexus/content/groups/public/ |
     Then s2i build log should contain Downloaded
 
- #CLOUD-3866
-  @ignore
   Scenario: Test galleon and app incremental build, no download of artifacts
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-galleon-incremental with env and True using master
+    | variable                                      | value         |
+    | MAVEN_REPOS                          | NEXUS  |
+    | NEXUS_MAVEN_REPO_ID         | nexus-jboss |
+    | NEXUS_MAVEN_REPO_NAME   | nexus-jboss  |
+    | NEXUS_MAVEN_REPO_RELEASES_UPDATE_POLICY | never |
+    | NEXUS_MAVEN_REPO_SNAPSHOTS_ENABLED | false |
+    | NEXUS_MAVEN_REPO_URL      | https://repository.jboss.org/nexus/content/groups/public/ |
     Then s2i build log should not contain Downloaded
 
- #CLOUD-3866
-  @ignore
   Scenario: Test galleon build, download of artifacts
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-galleon-incremental
+    | variable                                      | value         |
+    | MAVEN_REPOS                          | NEXUS  |
+    | NEXUS_MAVEN_REPO_ID         | nexus-jboss |
+    | NEXUS_MAVEN_REPO_NAME   | nexus-jboss  |
+    | NEXUS_MAVEN_REPO_RELEASES_UPDATE_POLICY | never |
+    | NEXUS_MAVEN_REPO_SNAPSHOTS_ENABLED | false |
+    | NEXUS_MAVEN_REPO_URL      | https://repository.jboss.org/nexus/content/groups/public/ |
     Then s2i build log should contain Downloaded
 
- #CLOUD-3866
-  @ignore
   Scenario: Test galleon incremental build, no download of artifacts
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-galleon-incremental with env and True using master
+    | variable                                      | value         |
+    | MAVEN_REPOS                          | NEXUS  |
+    | NEXUS_MAVEN_REPO_ID         | nexus-jboss |
+    | NEXUS_MAVEN_REPO_NAME   | nexus-jboss  |
+    | NEXUS_MAVEN_REPO_RELEASES_UPDATE_POLICY | never |
+    | NEXUS_MAVEN_REPO_SNAPSHOTS_ENABLED | false |
+    | NEXUS_MAVEN_REPO_URL      | https://repository.jboss.org/nexus/content/groups/public/ |
     Then s2i build log should not contain Downloaded
 
   Scenario: Test galleon artifacts are retrieved from galleon local cache


### PR DESCRIPTION
We don't need nexus repo when building FP and provisioning default server.
Unignored the failing tests. Added explicitly nexus repo in the tests.