### PR TITLE
Fix master branch to use wildfly-cekit-modules 0.22.0. We can't use c…

### DIFF
--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -34,7 +34,7 @@ modules:
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules
-              ref: master
+              ref: 0.22.0 
           - name: wildfly-s2i-modules
             path: ../wildfly-modules
       install:


### PR DESCRIPTION
…ct_modules 0.44.0

@luck3y FYI, we will need to update wildfly-s2i to use 0.44.0, but at first glance we are missing some maven modules.