### PR TITLE
Fix for Issue #145, Upgrade to WF 23 beta1

### DIFF
--- a/test/test-app-custom/galleon/provisioning.xml
+++ b/test/test-app-custom/galleon/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#22.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#23.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-jaxrs-exclude/galleon/provisioning.xml
+++ b/test/test-app-jaxrs-exclude/galleon/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#22.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#23.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-jaxrs-slim/galleon/provisioning.xml
+++ b/test/test-app-jaxrs-slim/galleon/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#22.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#23.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-jaxrs/galleon/provisioning.xml
+++ b/test/test-app-jaxrs/galleon/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <transitive>
-        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#22.0.0.Final">
+        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#23.0.0.Beta1">
             <default-configs inherit="false"/>
             <packages inherit="false">
                 <exclude name="org.jboss.resteasy.resteasy-multipart-provider"/>
@@ -21,7 +21,7 @@
     </transitive>
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#22.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#23.0.0.Final">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/test/test-app-share-galleon-artifacts/pom.xml
+++ b/test/test-app-share-galleon-artifacts/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-galleon-pack</artifactId>
-            <version>22.0.0.Final</version>
+            <version>23.0.0.Beta1</version>
             <type>zip</type>
         </dependency>
 

--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -12,7 +12,7 @@ labels:
     - name: io.openshift.expose-services
       value: "8080:http,8778:jolokia"
     - name: io.openshift.tags
-      value: "builder,wildfly,wildfly22"
+      value: "builder,wildfly,wildfly23"
     - name: maintainer
       value: "Jean-François Denise <jdenise@redhat.com>"
 envs:

--- a/wildfly-modules/jboss/container/wildfly/base/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/base/module.yaml
@@ -5,7 +5,7 @@ description: Module to setup WildFly env
 
 envs:
 - name: "WILDFLY_VERSION"
-  value: "22.0.0.Final"
+  value: "23.0.0.Beta1"
 
 modules:
   install:

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/fat-default-server/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/fat-default-server/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#22.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#23.0.0.Final">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/full-profile/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/full-profile/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <transitive>
-        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#22.0.0.Final">
+        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#23.0.0.Final">
             <default-configs inherit="true"/>
         </feature-pack>
     </transitive>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/slim-default-server/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/slim-default-server/provisioning.xml
@@ -3,7 +3,7 @@
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- workaround issue with  https://maven.repository.redhat.com/ga/org/wildfly/galleon/s2i/wildfly-s2i-galleon-pack/maven-metadata.xml
          that takes hour instead of returning 404, version is not needed -->
-    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#22.0.0.Final">
+    <feature-pack location="wildfly-s2i@maven(org.jboss.universe:s2i-universe):current#23.0.0.Final">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/standalone-profile/provisioning.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/definitions/standalone-profile/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <transitive>
-        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#22.0.0.Final">
+        <feature-pack location="wildfly@maven(org.jboss.universe:community-universe):current#23.0.0.Final">
             <default-configs inherit="false">
                 <include model="standalone" name="standalone.xml"/>
             </default-configs>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/pom.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wildfly.galleon.s2i</groupId>
     <artifactId>wildfly-s2i-galleon-pack</artifactId>
-    <version>22.0.0.Final</version>
+    <version>23.0.0.Final</version>
     <packaging>pom</packaging>
     <name>WildFly Galleon feature-pack for OpenShift</name>
   

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/artifacts/opt/jboss/container/wildfly/galleon/wildfly-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
@@ -23,12 +23,6 @@
 <build xmlns="urn:wildfly:feature-pack-build:3.1" producer="org.wildfly.galleon.s2i:wildfly-s2i-galleon-pack">
 
     <transitive>
-        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
-            <name>org.wildfly.core:wildfly-core-galleon-pack</name>
-        </dependency>
-        <dependency group-id="org.wildfly" artifact-id="wildfly-servlet-galleon-pack">
-            <name>org.wildfly:wildfly-servlet-galleon-pack</name>
-        </dependency>
         <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack">
             <name>org.wildfly:wildfly-ee-galleon-pack</name>
         </dependency>

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
@@ -5,9 +5,9 @@ description: Install Galleon descriptions and Wildfly s2i feature-pack. Configur
 
 envs:
 - name: S2I_FP_VERSION
-  value: "22.0.0.Final"
+  value: "23.0.0.Final"
 - name: WILDFLY_EXTRAS_DS_VERSION
-  value: "1.2.0.Final"      
+  value: "1.2.2.Final"      
 - name: GALLEON_DEFINITIONS
   value: /opt/jboss/container/wildfly/galleon/definitions
 - name: GALLEON_DEFAULT_SERVER

--- a/wildfly-runtime-image/image.yaml
+++ b/wildfly-runtime-image/image.yaml
@@ -8,7 +8,7 @@ labels:
     - name: io.openshift.expose-services
       value: "8080:http,8778:jolokia"
     - name: io.openshift.tags
-      value: "wildfly,wildfly22"
+      value: "wildfly,wildfly23"
     - name: maintainer
       value: "Jean-François Denise <jdenise@redhat.com>"
     - name: "org.jboss.deployments-dir"


### PR DESCRIPTION
Mainly removal of core and servlet dependencies for s2i feature-pack + some version changes. With this fix, the master branch can be used to build a builder image that contains WF 23 Beta1.