### PR TITLE
Script and github workflow to build/test/deploy an image based on wildfly-cekit-modules and wildfly-s2i branch

### DIFF
--- a/.github/workflows/custom-wf-cekit-build.yml
+++ b/.github/workflows/custom-wf-cekit-build.yml
@@ -1,0 +1,101 @@
+name: Wildfly s2i Image with custom wildfly-cekit-module
+on:
+  repository_dispatch:
+    types: [custom-wf-cekit-build]
+    paths-ignore:
+      - 'docs/**'
+env:
+  LANG: en_US.UTF-8
+  S2I_URI: https://api.github.com/repos/openshift/source-to-image/releases/latest
+  CEKIT_VERSION: 3.2.1
+  QUAY_REPO: ${{ secrets.QUAY_REPO }}
+  QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+  IMAGE_VERSION: wf-cekit-${{ github.event.client_payload.wf-cekit-ref }}
+  WFCEKIT_FORK: ${{ github.event.client_payload.wf-cekit-fork }}
+  WFCEKIT_BRANCH: ${{ github.event.client_payload.wf-cekit-ref }}
+jobs:
+  wfci:
+    name: Wildfly-s2i Build, Deploy and Test using custom wildfly-cekit-modules
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            ref: ${{ github.event.client_payload.wf-s2i-ref }}
+      - uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check quay.io configuration
+        if: env.QUAY_USERNAME == '' || env.QUAY_REPO == ''
+        run: |
+          echo "quay.io configuration is incomplete, push to quay.io will be skipped. If you wish to push built images to quay.io, please ensure the secrets QUAY_REPO, QUAY_USERNAME and QUAY_PASSWORD are created in the project."
+      - name: Verify latest centos image is present
+        run: |
+          docker image ls | grep centos || true
+          docker pull centos:7
+          docker pull centos/s2i-base-centos7
+          docker image ls | grep centos
+      - name: Setup required system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install krb5-multidev
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Setup virtualenv and install cekit and required packages
+        run: |
+          python --version
+          sudo pip install virtualenv
+          mkdir ~/cekit${{ env.CEKIT_VERSION }}
+          python3 -m venv ~/cekit${{ env.CEKIT_VERSION }}
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          pip install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml 
+      - name: install s2i binary
+        run: |
+          echo ===== Installing s2i from ${{ env.S2I_URL }} =====
+          mkdir /tmp/s2i/ && cd /tmp/s2i/
+          curl -s ${{ env.S2I_URI }} \
+           | grep browser_download_url \
+           | grep linux-amd64 \
+           | cut -d '"' -f 4 \
+           | wget -qi -
+           tar xvf source-to-image*.gz
+           sudo mv s2i /usr/bin
+           which s2i
+           s2i version
+      - name: Build
+        run: |
+          pushd tools
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          sh ./build-custom-s2i-wf-cekit-image.sh  ${{ env.IMAGE_VERSION }} ${{ env.WFCEKIT_FORK }} ${{ env.WFCEKIT_BRANCH }}
+          popd
+          docker image ls
+      - name: Push to quay.io
+        if: env.QUAY_USERNAME != '' && env.QUAY_REPO != ''
+        run: |
+            BUILDER_IMAGE="quay.io/${{ secrets.QUAY_REPO }}/wildfly-centos7:${{ env.IMAGE_VERSION }}"
+            echo QUAY_REPO: "${{ secrets.QUAY_REPO }}"
+            echo Pushing to quay.io with the tag :${{ env.IMAGE_VERSION }}
+            echo BUILDER_IMAGE: ${BUILDER_IMAGE}
+            docker login -u="${{ secrets.QUAY_USERNAME }}" -p="${{ secrets.QUAY_PASSWORD }}" quay.io
+            docker tag wildfly/wildfly-centos7:latest ${BUILDER_IMAGE}
+            docker push ${BUILDER_IMAGE}
+      - name: Behave Tests
+        run: |
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          pushd wildfly-builder-image
+          cekit -v test --image=wildfly/wildfly-centos7:latest behave
+          popd
+      - name: Additional Tests
+        run: |
+          export IMAGE_VERSION=latest
+          export NAMESPACE=wildfly
+          export PLATFORM=centos7
+          export IMAGE_NAME=${NAMESPACE}/wildfly-${PLATFORM}
+          export RUNTIME_IMAGE_NAME=quay.io/${NAMESPACE}/wildfly-runtime-${PLATFORM}
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          ./test/run

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,61 @@
+Tools to help you build S2I images
+=====================
+
+build-s2i-image.sh
+===========
+
+* You want to create locally a wildfly-s2i image that depends on a local build of WildFly.
+* You must have cekit and docker setup.
+
+Usage: 
+
+```
+$ ./build-s2i-image.sh <path to wildfly built with -Drelease> --no-wildfly-build
+```
+
+build-app-image.sh
+============
+
+* You want to build locally an application image using s2i
+* You must have cekit, s2i and docker setup.
+* By default it uses `quay.io/wildfly/wildfly-centos7` and `quay.io/wildfly/wildfly-runtime-centos7` images. You can provide your own wildfly s2i builder and runtime images.
+* If no application name is provided, the image name is derived from the application src directory.
+* You can provide Galleon layers in order to build a trimmed-down server.
+
+Usage:
+
+```
+$ ./build-app-image.sh <path to your app maven project> [--app-name=<application name>] [--galleon-layers=<comma separated list of layers>] [--wildfly-builder-image=<wildfly s2i builder image>] [--wildfly-runtime-image=<wildfly runtime image>]
+```
+github-deploy.sh
+==========
+
+* Github action workflow.
+* You want to build/test/deploy to quay.io the wildfly-s2i image from the http://github.com/wildfly/wildfly-s2i master branch
+* You must set ```WILDFLYS2I_GITHUB_PAT``` env variable to your GITHUB Personal Access Token.
+* If you want the images to be pushed to your quay.io account (that must contain wildfly-centos7 and wildfly-runtime-centos7 repositories), you must set the following secrets: ```QUAY_REPO, QUAY_USERNAME, QUAY_PASSWORD```
+
+Usage:
+
+```
+$ ./github-deploy.sh
+```
+
+github-wf-cekit-build.sh
+==============
+
+* Github action workflow.
+* You have opened a PR against wildfly-cekit-modules and want to build/test/deploy to quay.io a wildfly-s2i image that depends on it
+* You have possibly some changes in a wildfly-s2i branch.
+* You don't have cekit, docker setup, or you don't want to build the image locally
+* You must set ```WILDFLYS2I_GITHUB_PAT``` env variable to your GITHUB Personal Access Token.
+* By default master branch of repositories in the wildfly organisation are used.
+* To reference your own forks, branches use ```WILDFLYS2I_FORK_NAME```, ```WILDFLYS2I_BRANCH_NAME```, ```WILDFLYCEKIT_FORK_NAME``` and ```WILDFLYCEKIT_BRANCH_NAME```
+* If you want the images to be pushed to your quay.io account (that must contain wildfly-centos7 and wildfly-runtime-centos7 repositories), you must set the following secrets: ```QUAY_REPO, QUAY_USERNAME, QUAY_PASSWORD```
+* The pushed image version is:```wf-cekit-<wildfly-cekit-module branch>```
+
+Usage:
+
+```
+$ ./github-wf-cekit-build.sh
+```

--- a/tools/build-custom-s2i-wf-cekit-image.sh
+++ b/tools/build-custom-s2i-wf-cekit-image.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+SCRIPT_DIR=$(dirname $0)
+version=$1
+cekitFork=$2
+cekitBranch=$3
+buildImageDir=$SCRIPT_DIR/../wildfly-builder-image
+overridesFile=$buildImageDir/custom-wf-cekit-modules.yaml
+buildEngine=docker
+
+sed -i "s|###IMG_VERSION###|$version|" "$overridesFile"
+sed -i "s|###FORK_NAME###|$cekitFork|" "$overridesFile"
+sed -i "s|###CEKIT_BRANCH###|$cekitBranch|" "$overridesFile"
+
+echo Using overrides file content:
+echo #########################
+echo
+cat $overridesFile
+echo
+echo #########################
+
+cd $buildImageDir
+  cekit build --overrides=$overridesFile ${buildEngine}
+  if [ $? != 0 ]; then
+    echo ERROR: Building image failed.
+    exit 1
+  fi
+cd $SCRIPT_DIR
+
+echo "Done!"

--- a/tools/github-wf-cekit-build.sh
+++ b/tools/github-wf-cekit-build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+if [ -z "${WILDFLYS2I_FORK_NAME}" ];
+then
+  WILDFLYS2I_FORK_NAME="wildfly"
+fi
+
+echo "Using wildfly-s2i repo http://github.com/${WILDFLYS2I_FORK_NAME}/wildfly-s2i"
+
+if [ -z "${WILDFLYS2I_BRANCH_NAME}" ];
+then
+  WILDFLYS2I_BRANCH_NAME="master"
+fi
+
+echo "Using wildfly-s2i ${WILDFLYS2I_BRANCH_NAME} branch"
+
+if [ -z "${WILDFLYCEKIT_FORK_NAME}" ];
+then
+  WILDFLYCEKIT_FORK_NAME="wildfly"
+fi
+
+echo "Using wildfly-cekit-modules repo http://github.com/${WILDFLYCEKIT_FORK_NAME}/wildfly-cekit-modules"
+
+if [ -z "${WILDFLYCEKIT_BRANCH_NAME}" ];
+then
+  WILDFLYCEKIT_BRANCH_NAME="master"
+fi
+
+echo "Using wildfly-cekit-modules '${WILDFLYCEKIT_BRANCH_NAME}' branch"
+
+# this is the path to the repo the build should run from. It should not begin with a leading /.
+WILDFLY_REPO="${WILDFLYS2I_FORK_NAME}/wildfly-s2i/dispatches"
+
+if [ -z "${WILDFLYS2I_GITHUB_PAT}" ];
+then
+    echo
+    echo "Using this script requires the creation of a personal access token here: https://github.com/settings/tokens"
+    echo "The token should have the following permissions: repo:status, repo_deployment, public_repo, read:packages, read:discussion, workflow"
+    echo "Then export the token in your current shell: export WILDFLYS2I_GITHUB_PAT=... and re-run this script."
+    echo
+else
+    curl \
+    -X POST \
+    -H "Authorization: token $WILDFLYS2I_GITHUB_PAT" \
+    -H "Accept: application/vnd.github.ant-man-preview+json" \
+    -H "Content-Type: application/json" \
+    https://api.github.com/repos/${WILDFLY_REPO} \
+    --data '{"event_type": "custom-wf-cekit-build", "client_payload": { "wf-s2i-ref": "'"${WILDFLYS2I_BRANCH_NAME}"'", "wf-cekit-fork": "'"$WILDFLYCEKIT_FORK_NAME"'", "wf-cekit-ref": "'"$WILDFLYCEKIT_BRANCH_NAME"'"  } }'
+fi

--- a/wildfly-builder-image/custom-wf-cekit-modules.yaml
+++ b/wildfly-builder-image/custom-wf-cekit-modules.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+
+name: "wildfly/wildfly-centos7"
+version: "###IMG_VERSION###"
+
+modules:
+      repositories:
+          - name: cct_module
+            git:
+              url: https://github.com/jboss-openshift/cct_module
+              ref: 0.45.1
+          - name: wildfly-cekit-modules
+            git:
+              url: https://github.com/###FORK_NAME###/wildfly-cekit-modules
+              ref: ###CEKIT_BRANCH###
+          - name: wildfly-s2i-modules
+            path: ../wildfly-modules


### PR DESCRIPTION
* Added new worklfow useful when you have a PR open in wildfly-cekit-modules and want to build a wildfly s2i builder image that depends on it. The script allows to set fork/branch for both wildfly-s2i and wildfly-cekit-modules.
* Added README.md to document tools.
