### PR TITLE
Updated tooling to build/deploy custom image with custom wildfly-cekit-modules

### DIFF
--- a/.github/workflows/custom-wf-cekit-build.yml
+++ b/.github/workflows/custom-wf-cekit-build.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install krb5-multidev
+          sudo apt-get install bash
       - name: Setup Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -71,7 +72,7 @@ jobs:
         run: |
           pushd tools
           . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          sh ./build-custom-s2i-wf-cekit-image.sh  ${{ env.IMAGE_VERSION }} ${{ env.WFCEKIT_FORK }} ${{ env.WFCEKIT_BRANCH }}
+          bash ./build-custom-s2i-wf-cekit-image.sh  ${{ env.IMAGE_VERSION }} ${{ env.WFCEKIT_FORK }} ${{ env.WFCEKIT_BRANCH }}
           popd
           docker image ls
       - name: Push to quay.io

--- a/tools/build-custom-s2i-wf-cekit-image.sh
+++ b/tools/build-custom-s2i-wf-cekit-image.sh
@@ -4,7 +4,11 @@ version=$1
 cekitFork=$2
 cekitBranch=$3
 buildImageDir=$SCRIPT_DIR/../wildfly-builder-image
+modulesDir=$SCRIPT_DIR/../wildfly-modules
+customModule=$modulesDir/jboss/container/wildfly/base/custom/module.yaml
+customModuleCopy=$modulesDir/jboss/container/wildfly/base/custom/module.yaml.orig
 overridesFile=$buildImageDir/custom-wf-cekit-modules.yaml
+generatorJar=$SCRIPT_DIR/maven-repo-generator/target/maven-repo-generator-1.0.jar
 buildEngine=docker
 
 sed -i "s|###IMG_VERSION###|$version|" "$overridesFile"
@@ -18,12 +22,60 @@ cat $overridesFile
 echo
 echo #########################
 
-cd $buildImageDir
-  cekit build --overrides=$overridesFile ${buildEngine}
+cloudFpPath="${SCRIPT_DIR}/../wildfly-cloud-legacy-galleon-pack"
+cloudFpPathCopy=/tmp/wildfly-cloud-legacy-galleon-pack
+rm -rf "${cloudFpPathCopy}"
+cp -r "${cloudFpPath}" /tmp
+
+pushd "${cloudFpPathCopy}"
+mvn versions:set -DnewVersion=$version
+#Retrieve WildFly version
+wildflyVersion=$(mvn help:evaluate -Dexpression=version.org.wildfly -q -DforceStdout)
+#Build cloud fp
+mvn clean install -Dwildfly.cekit.modules.tag=$cekitBranch -Dwildfly.cekit.modules.fork=$cekitFork -Drelease
+
+popd
+
+offliner=$(find "${cloudFpPathCopy}/release/target/" -type f -iname "*-all-artifacts-list.txt")
+if [ ! -f "$offliner" ]; then
+  echo ERROR: Offliner file not found in  $cloudFpPathCopy/release/target/
+  exit 1
+fi
+
+if [ ! -f "$generatorJar" ]; then
+  mvn -f $SCRIPT_DIR/maven-repo-generator/pom.xml clean package
   if [ $? != 0 ]; then
-    echo ERROR: Building image failed.
+    echo ERROR: Building repo generator failed.
     exit 1
   fi
-cd $SCRIPT_DIR
+fi
 
+echo "Generating zipped maven repository"
+java -jar $generatorJar $offliner > /dev/null 2>&1 
+if [ $? != 0 ]; then
+  echo ERROR: Building maven repo failed.
+  exit 1
+fi
+mv maven-repo.zip /tmp
+echo "Zipped maven repository generated in /tmp/maven-repo.zip"
+
+cp "$customModule" "$customModuleCopy"
+sed -i "s|###WILDFLY_SNAPSHOT_VERSION###|$wildflyVersion|" "$customModule"
+sed -i "s|###CLOUD_SNAPSHOT_VERSION###|$version|" "$customModule"
+echo "Patched $customModule with proper version $version"
+
+pushd $buildImageDir
+cekit build --overrides=$overridesFile ${buildEngine}
+if [ $? != 0 ]; then
+  echo ERROR: Building image failed.
+fi
+popd
+
+mv $customModuleCopy $customModule
+echo "Reverted changes done to $customModule"
+rm -rf /tmp/maven-repo.zip
+echo "/tmp/maven-repo.zip deleted"
+rm -rf "${cloudFpPathCopy}"
+echo "${cloudFpPathCopy} deleted"
+rm -f errors.log
 echo "Done!"

--- a/tools/build-s2i-image.sh
+++ b/tools/build-s2i-image.sh
@@ -69,7 +69,8 @@ mv maven-repo.zip /tmp
 echo "Zipped maven repository generated in /tmp/maven-repo.zip"
 
 cp "$customModule" "$customModuleCopy"
-sed -i "s|###SNAPSHOT_VERSION###|$version|" "$customModule"
+sed -i "s|###WILDFLY_SNAPSHOT_VERSION###|$version|" "$customModule"
+sed -i "s|###CLOUD_SNAPSHOT_VERSION###|$version|" "$customModule"
 echo "Patched $customModule with proper version $version"
 
 pushd $buildImageDir > /dev/null

--- a/tools/maven-repo-generator/src/main/java/org/wildfly/galleon/maven/repo/generator/Main.java
+++ b/tools/maven-repo-generator/src/main/java/org/wildfly/galleon/maven/repo/generator/Main.java
@@ -48,7 +48,7 @@ public class Main {
             Path repoPath = tmpPath.resolve("wildfly-snapshot-image-builder-maven-repository");
             Files.createDirectory(repoPath);
             repoPath = repoPath.resolve("maven-repository");
-            String[] offlinerArgs = {"--url", "http://127.0.0.1:7777", offlinerFile.toString(), "--dir", repoPath.toString()};
+            String[] offlinerArgs = {"--url", "http://127.0.0.1:7777", "--url", "https://maven.repository.redhat.com/ga/", "--url", "https://repository.jboss.org/nexus/content/groups/public/", offlinerFile.toString(), "--dir", repoPath.toString()};
             com.redhat.red.offliner.Main.main(offlinerArgs);
             System.out.println("\nZipping repo...");
             zipRepo(tmpPath, zipFile);

--- a/wildfly-builder-image/custom-wf-cekit-modules.yaml
+++ b/wildfly-builder-image/custom-wf-cekit-modules.yaml
@@ -15,3 +15,7 @@ modules:
               ref: ###CEKIT_BRANCH###
           - name: wildfly-s2i-modules
             path: ../wildfly-modules
+      
+      install:
+          - name: jboss.container.wildfly.base
+            version: "custom"

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/install-cct-module.sh
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/install-cct-module.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copy logging.sh file that is expected by launch scripts to be in JBOSS_HOME/bin/launch
 SCRIPT_DIR=$(pwd -P)/$(dirname $0)
 tmp_dir="$SCRIPT_DIR/target/tmp"
@@ -9,6 +9,7 @@ common_package_dir="$packages_dir/wildfly.s2i.common/content"
 mkdir -p $common_package_dir
 mkdir -p $tmp_dir
 pushd "$tmp_dir"
+  echo "git clone -b $CCT_MODULES_TAG http://github.com/$CCT_MODULES_FORK/cct_module"
   git clone -b $CCT_MODULES_TAG http://github.com/$CCT_MODULES_FORK/cct_module
   mkdir -p "$common_package_dir/bin/launch"
   cp cct_module/jboss/container/util/logging/bash/artifacts/opt/jboss/container/util/logging/logging.sh "$common_package_dir/bin/launch"

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/install-cekit-modules.sh
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/install-cekit-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Install launch scripts.
 SCRIPT_DIR=$(pwd -P)/$(dirname $0)
 tmp_dir="$SCRIPT_DIR/target/tmp"
@@ -9,6 +9,7 @@ common_package_dir="$packages_dir/wildfly.s2i.common/content"
 mkdir -p $common_package_dir
 mkdir -p $tmp_dir
 pushd "$tmp_dir"
+  echo "git clone -b $WILDFLY_CEKIT_TAG http://github.com/$WILDFLY_CEKIT_FORK/wildfly-cekit-modules"
   git clone -b $WILDFLY_CEKIT_TAG http://github.com/$WILDFLY_CEKIT_FORK/wildfly-cekit-modules 
   export JBOSS_HOME="$common_package_dir"
   mkdir -p "$JBOSS_HOME/bin/launch"

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/install-keycloak.sh
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/install-keycloak.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #install keycloak oidc and saml adapters, generated feature-group to reference thekeycloak  JBoss modules modules.
 SCRIPT_DIR=$(dirname $0)
 wget -c https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-oidc-wildfly-adapter-${KEYCLOAK_VERSION}.zip -O keycloak-oidc-wildfly-adapter.zip

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/pom.xml
@@ -38,6 +38,13 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <cct.module.fork>jboss-openshift</cct.module.fork>
+        <cct.module.tag>0.45.1</cct.module.tag>
+        <version.keycloak>12.0.4</version.keycloak>
+        <wildfly.cekit.modules.fork>wildfly</wildfly.cekit.modules.fork>
+        <wildfly.cekit.modules.tag>master</wildfly.cekit.modules.tag>
+    </properties>
     <build>                
         <plugins>
             <plugin>
@@ -49,15 +56,15 @@
                         <configuration>
                             <tasks>
                                 <exec executable="./install-cct-module.sh">
-                                    <env key="CCT_MODULES_TAG" value="0.45.1"/>
-                                    <env key="CCT_MODULES_FORK" value="jboss-openshift"/>
+                                    <env key="CCT_MODULES_TAG" value="${cct.module.tag}"/>
+                                    <env key="CCT_MODULES_FORK" value="${cct.module.fork}"/>
                                 </exec>
                                 <exec executable="./install-cekit-modules.sh">
-                                    <env key="WILDFLY_CEKIT_TAG" value="master"/>
-                                    <env key="WILDFLY_CEKIT_FORK" value="wildfly"/>
+                                    <env key="WILDFLY_CEKIT_TAG" value="${wildfly.cekit.modules.tag}"/>
+                                    <env key="WILDFLY_CEKIT_FORK" value="${wildfly.cekit.modules.fork}"/>
                                 </exec>
                                 <exec executable="./install-keycloak.sh">
-                                    <env key="KEYCLOAK_VERSION" value="12.0.4"/>
+                                    <env key="KEYCLOAK_VERSION" value="${version.keycloak}"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/wildfly-cloud-legacy-galleon-pack/release/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/release/pom.xml
@@ -67,7 +67,7 @@
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>
-                                    <offline>true</offline>
+                                    <offline>false</offline>
                                     <fpGroupId>${project.groupId}</fpGroupId>
                                     <fpArtifactId>wildfly-cloud-legacy-galleon-pack</fpArtifactId>
                                     <fpVersion>${project.version}</fpVersion>

--- a/wildfly-modules/jboss/container/wildfly/base/custom/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/base/custom/module.yaml
@@ -6,9 +6,9 @@ description: Module to setup WildFly env for a cutom build
 envs:
 - name: "WILDFLY_VERSION"
   # Version patched by tools/build-s2i-image.sh
-  value: "###SNAPSHOT_VERSION###"
+  value: "###WILDFLY_SNAPSHOT_VERSION###"
 - name:  "WILDFLY_CLOUD_LEGACY_GALLEON_PACK_VERSION"
-  value: "###SNAPSHOT_VERSION###"
+  value: "###CLOUD_SNAPSHOT_VERSION###"
 
 artifacts:
   - name: maven-repo.zip


### PR DESCRIPTION
This is the last tool that needed changes to use the new approach based on the wildfly-cloud-legacy-galleon-pack.
* Updated github action to use bash
* Changed logic to build an image based on on a custom wildfly-cekit-modules tag/fork
* Make changes to allow to build the cloud FP from github action (force use of bash, offline=false, we are starting from an empty maven repo).
* Added remote maven repos to the maven repo generator to make it usable from github action.

Passing github action: https://github.com/jfdenise/wildfly-s2i/actions/runs/904194557