### PR TITLE
 Upgrade WildFly s2i dependencies on WF 24.0.0.Beta1

### DIFF
--- a/wildfly-cloud-legacy-galleon-pack/examples/default-configs/provisioning.xml
+++ b/wildfly-cloud-legacy-galleon-pack/examples/default-configs/provisioning.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" ?>
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
-    <feature-pack location="org.wildfly:wildfly-cloud-legacy-galleon-pack:23.0.2.Beta1">
+    <feature-pack location="org.wildfly:wildfly-cloud-legacy-galleon-pack:24.0.0.Alpha1">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>
     </feature-pack>
-    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:2.0.0.Final">
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:2.0.1.Final">
     </feature-pack>
 </installation>

--- a/wildfly-cloud-legacy-galleon-pack/examples/jaxws/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/examples/jaxws/pom.xml
@@ -68,10 +68,10 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>4.0.3.Final</version>
+                <version>5.0.0.Beta1</version>
                 <configuration>
                     <context-root>false</context-root>
-                    <feature-pack-location>org.wildfly:wildfly-cloud-legacy-galleon-pack:23.0.2.Beta1</feature-pack-location>
+                    <feature-pack-location>org.wildfly:wildfly-cloud-legacy-galleon-pack:24.0.0.Alpha1</feature-pack-location>
                     <layers>
                         <layer>jaxrs-server</layer>
                         <layer>webservices</layer>

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-cloud-legacy-galleon-pack-parent</artifactId>
-        <version>23.0.2.Beta1</version>
+        <version>24.0.0.Alpha1</version>
     </parent>
     <artifactId>wildfly-cloud-legacy-galleon-pack</artifactId>
     <packaging>pom</packaging>
@@ -43,7 +43,7 @@
         <cct.module.tag>0.45.1</cct.module.tag>
         <version.keycloak>12.0.4</version.keycloak>
         <wildfly.cekit.modules.fork>wildfly</wildfly.cekit.modules.fork>
-        <wildfly.cekit.modules.tag>master</wildfly.cekit.modules.tag>
+        <wildfly.cekit.modules.tag>0.24.0</wildfly.cekit.modules.tag>
     </properties>
     <build>                
         <plugins>

--- a/wildfly-cloud-legacy-galleon-pack/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.wildfly</groupId>
     <artifactId>wildfly-cloud-legacy-galleon-pack-parent</artifactId>
-    <version>23.0.2.Beta1</version>
+    <version>24.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>WildFly legacy Galleon feature-pack for Cloud parent</name>
   
@@ -40,7 +40,7 @@
     </licenses>
     
     <properties>
-        <version.org.wildfly>23.0.2.Final</version.org.wildfly>
+        <version.org.wildfly>24.0.0.Beta1</version.org.wildfly>
         <version.org.wildfly.galleon-plugins>5.2.0.Alpha2</version.org.wildfly.galleon-plugins>
     </properties>
 

--- a/wildfly-cloud-legacy-galleon-pack/release/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/release/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-cloud-legacy-galleon-pack-parent</artifactId>
-        <version>23.0.2.Beta1</version>
+        <version>24.0.0.Alpha1</version>
     </parent>
     <artifactId>wildfly-cloud-legacy-galleon-pack-release</artifactId>
     <packaging>pom</packaging>

--- a/wildfly-modules/jboss/container/wildfly/base/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/base/module.yaml
@@ -5,9 +5,9 @@ description: Module to setup WildFly env
 
 envs:
 - name: "WILDFLY_VERSION"
-  value: "23.0.2.Final"
+  value: "24.0.0.Beta1"
 - name:  WILDFLY_CLOUD_LEGACY_GALLEON_PACK_VERSION
-  value: "23.0.2.Beta1"
+  value: "24.0.0.Alpha1"
 - name: "CLI_GRACEFUL_SHUTDOWN"
   example: "true"
   description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."

--- a/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/galleon-wildfly/module.yaml
@@ -7,7 +7,7 @@ envs:
 - name: S2I_FP_VERSION
   value: "23.0.0.Final"
 - name: WILDFLY_EXTRAS_DS_VERSION
-  value: "2.0.0.Final"
+  value: "2.0.1.Final"
 - name: GALLEON_DEFINITIONS
   value: /opt/jboss/container/wildfly/galleon/definitions
 - name: GALLEON_DEFAULT_SERVER


### PR DESCRIPTION
* A wildfly-cloud-legacy-galleon-pack 24.0.0.Alpha1 has been released. This image depends on it.
* Upgraded to latest datasources-galleon-pack 2.0.1.FInal