### PR TITLE
Keycloak example, add missing dependency caused by version upgrade

### DIFF
--- a/test/test-app-keycloak/app-profile-jee-saml/pom.xml
+++ b/test/test-app-keycloak/app-profile-jee-saml/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-api-public</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-adapter-spi</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/test/test-app-keycloak/pom.xml
+++ b/test/test-app-keycloak/pom.xml
@@ -78,6 +78,11 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-saml-adapter-api-public</artifactId>
+                <version>${version.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-adapter-spi</artifactId>
                 <version>${version.keycloak}</version>
             </dependency>


### PR DESCRIPTION
Update test app tha tfails to compile.
This change must be first merged for the tests to e run with an update app.