### PR TITLE
Fix tests to properly kill the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 Wildfly - UBI8 Docker S2i builder image
 ========================
-
 TBD

--- a/wildfly-builder-image/tests/features/basic.feature
+++ b/wildfly-builder-image/tests/features/basic.feature
@@ -89,8 +89,8 @@ Feature: Wildfly basic tests
     When container integ- is started with env
       | variable                                    | value                     |
       | JAVA_OPTS                               | -Xmx64m -Xms64m |
-    Then container log should contain WFLYSRV0025
-    And run kill -TERM 1 in container once
+    Then exactly 2 times container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container and detach
     And container log should contain received TERM signal
     And exactly 2 times container log should contain WFLYSRV0050
 
@@ -99,8 +99,8 @@ Feature: Wildfly basic tests
        | variable                  | value           |
        | CLI_GRACEFUL_SHUTDOWN     | true            |
        | JAVA_OPTS                               | -Xmx64m -Xms64m |
-    Then container log should contain WFLYSRV0025
-    And run kill -TERM 1 in container once
+    Then exactly 2 times container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container and detach
     And container log should not contain received TERM signal
     And exactly 1 times container log should contain WFLYSRV0050
 
@@ -109,8 +109,8 @@ Feature: Wildfly basic tests
        | variable                  | value           |
        | CLI_GRACEFUL_SHUTDOWN     | true            |
        | JAVA_OPTS                               | -Xmx64m -Xms64m |
-    Then container log should contain WFLYSRV0025
-    Then run /opt/server/bin/jboss-cli.sh -c "shutdown --timeout=60" in container once
+    Then exactly 2 times container log should contain WFLYSRV0025
+    Then run /opt/server/bin/jboss-cli.sh -c "shutdown --suspend-timeout=60" in container and detach
     Then container log should not contain received TERM signal
     Then exactly 2 times container log should contain WFLYSRV0050
 
@@ -118,8 +118,8 @@ Feature: Wildfly basic tests
     When container integ- is started with env
        | variable                  | value           |
        | JAVA_OPTS                               | -Xmx64m -Xms64m |
-    Then container log should contain WFLYSRV0025
-    And run kill -TERM 1 in container once
+    Then exactly 2 times container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container and detach
     And container log should contain received TERM signal
     And container log should contain WFLYSRV0241
     And exactly 2 times container log should contain WFLYSRV0050

--- a/wildfly-builder-image/tests/features/vanilla-basic.feature
+++ b/wildfly-builder-image/tests/features/vanilla-basic.feature
@@ -170,7 +170,7 @@ Scenario: Check if image shuts down with TERM signal
       | variable              | value    |
       | JAVA_OPTS                               | -Xmx64m -Xms64m |
     Then container log should contain WFLYSRV0025
-    And run kill -TERM 1 in container once
+    And run kill -TERM 1 in container and detach
     And container log should contain received TERM signal
     And exactly 1 times container log should contain WFLYSRV0050
 
@@ -180,7 +180,7 @@ Scenario: Check if image shuts down with TERM signal
        | CLI_GRACEFUL_SHUTDOWN     | true            |
        | JAVA_OPTS                               | -Xmx64m -Xms64m |
     Then container log should contain WFLYSRV0025
-    And run kill -TERM 1 in container once
+    And run kill -TERM 1 in container and detach
     And container log should not contain received TERM signal
     And container log should not contain WFLYSRV0050
 
@@ -190,7 +190,7 @@ Scenario: Check if image shuts down with TERM signal
        | CLI_GRACEFUL_SHUTDOWN     | true            |
        | JAVA_OPTS                               | -Xmx64m -Xms64m |
     Then container log should contain WFLYSRV0025
-    Then run /opt/server/bin/jboss-cli.sh -c "shutdown --timeout=60" in container once
+    Then run /opt/server/bin/jboss-cli.sh -c "shutdown --suspend-timeout=60" in container and detach
     Then container log should not contain received TERM signal
     Then exactly 1 times container log should contain WFLYSRV0050
 
@@ -199,7 +199,7 @@ Scenario: Check if image shuts down with TERM signal
     | variable                  | value           |
      | JAVA_OPTS                               | -Xmx64m -Xms64m |
     Then container log should contain WFLYSRV0025
-    And run kill -TERM 1 in container once
+    And run kill -TERM 1 in container and detach
     And container log should contain received TERM signal
     And container log should contain WFLYSRV0241
     And exactly 1 times container log should contain WFLYSRV0050


### PR DESCRIPTION
* Some tests are explicitly killing the server. The kill command must be sent in "detached" mode to avoid the command being killed when the container exit.
* Fixed tests that provision the legacy feature-pack to wait for the server to be fully initialized before to send the kill command.