### PR TITLE
Fix dmr version to be retrieved locally

### DIFF
--- a/test/test-app-share-galleon-artifacts/pom.xml
+++ b/test/test-app-share-galleon-artifacts/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-dmr</artifactId>
-            <version>1.5.1.Final</version>
+            <version>1.6.1.Final</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Test application only, this change is needed by tests run against Wildfly 25 Beta S2i. Must be merged prior to run tests.