### PR TITLE
Changes required for WildFly 25 Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ file inside your source code repository.
 
     * Openshift Decorator layers (to be used to complement base layers):
 
-      * `keycloak`: Keycloak integration.
+      * [DEPRECATED] `keycloak`: Keycloak integration. This layer is deprecated and would be remove in a future release.
 
       * `observability`: MP Health, Metrics, Config, OpenTracing.
 
@@ -265,11 +265,9 @@ WildFly server env variables
 
 * Filters (Undertow) [env vars](https://github.com/wildfly/wildfly-cekit-modules/blob/master/jboss/container/wildfly/launch/filters/module.yaml)
 
-* HTTPS config [env vars](https://github.com/wildfly/wildfly-cekit-modules/blob/master/jboss/container/wildfly/launch/https/module.yaml)
-
 * JSON logging [env vars](https://github.com/wildfly/wildfly-cekit-modules/blob/master/jboss/container/wildfly/launch/json-logging/module.yaml)
 
-* Keycloak [env var](https://github.com/wildfly/wildfly-cekit-modules/blob/master/jboss/container/wildfly/launch/keycloak/module.yaml)
+* [DEPRECATED] Keycloak [env var](https://github.com/wildfly/wildfly-cekit-modules/blob/master/jboss/container/wildfly/launch/keycloak/module.yaml)
 
 * Logger categories [env vars](https://github.com/wildfly/wildfly-cekit-modules/tree/master/jboss/container/wildfly/launch/logger-category/module.yaml)
 

--- a/wildfly-cloud-legacy-galleon-pack/examples/default-configs/provisioning.xml
+++ b/wildfly-cloud-legacy-galleon-pack/examples/default-configs/provisioning.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
-    <feature-pack location="org.wildfly:wildfly-cloud-legacy-galleon-pack:24.0.1.SP2">
+    <feature-pack location="org.wildfly:wildfly-cloud-legacy-galleon-pack:25.0.0.Beta1">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>

--- a/wildfly-cloud-legacy-galleon-pack/examples/jaxws/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/examples/jaxws/pom.xml
@@ -71,7 +71,7 @@
                 <version>6.0.0.Beta1</version>
                 <configuration>
                     <context-root>false</context-root>
-                    <feature-pack-location>org.wildfly:wildfly-cloud-legacy-galleon-pack:24.0.1.SP2</feature-pack-location>
+                    <feature-pack-location>org.wildfly:wildfly-cloud-legacy-galleon-pack:25.0.0.Beta1</feature-pack-location>
                     <layers>
                         <layer>jaxrs-server</layer>
                         <layer>webservices</layer>

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-cloud-legacy-galleon-pack-parent</artifactId>
-        <version>24.0.1.SP2</version>
+        <version>25.0.0.Beta1</version>
     </parent>
     <artifactId>wildfly-cloud-legacy-galleon-pack</artifactId>
     <packaging>pom</packaging>

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -6,18 +6,6 @@
         <include name="mysql-datasource"/>
         <include name="postgresql-datasource"/>
     </layers>
-    
-    <!-- remove elytron security that core-tools bring, we should be able to exclude management but we can't due to GAL-308 -->
-    <!-- START workaround GAL-308 -->
-    <exclude spec="core-service.management.access.identity"/>
-    <feature spec="core-service.management.management-interface.http-interface">
-        <param name="socket-binding" value="management-http"/>
-        <unset param="http-authentication-factory"/>
-        <feature spec="core-service.management.management-interface.http-interface.http-upgrade">
-            <unset param="sasl-authentication-factory"/>
-        </feature>
-    </feature>
-    <!-- END workaround GAL-308 -->
 
     <!-- remove opentracing extension and subsystem -->
     <exclude spec="subsystem.microprofile-opentracing-smallrye"/>
@@ -35,9 +23,6 @@
         <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
     </feature>
     
-    <!-- core realm -->
-    <exclude feature-id="core-service.management.security-realm.server-identity.ssl:security-realm=ApplicationRealm"/>
-
     <!-- undertow -->
     <exclude feature-id="subsystem.undertow.server.https-listener:server=default-server,https-listener=https"/>
 

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/src/main/resources/layers/standalone/application-security-realm/layer-spec.xml
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/src/main/resources/layers/standalone/application-security-realm/layer-spec.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="application-security-realm">
-    <exclude feature-id="core-service.management.security-realm.server-identity.ssl:security-realm=ApplicationRealm"/>
-</layer-spec>

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/src/main/resources/packages/wildfly.s2i.common/content/bin/launch/launch-config.sh
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/src/main/resources/packages/wildfly.s2i.common/content/bin/launch/launch-config.sh
@@ -14,7 +14,6 @@ CONFIG_SCRIPT_CANDIDATES=(
   $JBOSS_HOME/bin/launch/deploymentScanner.sh
   $JBOSS_HOME/bin/launch/elytron.sh
   $JBOSS_HOME/bin/launch/filters.sh
-  $JBOSS_HOME/bin/launch/https.sh
   $JBOSS_HOME/bin/launch/jgroups.sh
   $JBOSS_HOME/bin/launch/ha.sh
   $JBOSS_HOME/bin/launch/json_logging.sh

--- a/wildfly-cloud-legacy-galleon-pack/feature-pack/wf-cekit-modules-launch-list.txt
+++ b/wildfly-cloud-legacy-galleon-pack/feature-pack/wf-cekit-modules-launch-list.txt
@@ -5,7 +5,6 @@ deployment-scanner
 elytron
 extensions
 filters
-https
 jgroups
 json-logging
 keycloak
@@ -15,6 +14,5 @@ mp-config
 os.node-name
 port-offset
 resource-adapters
-security-domains
 statefulset
 tracing

--- a/wildfly-cloud-legacy-galleon-pack/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.wildfly</groupId>
     <artifactId>wildfly-cloud-legacy-galleon-pack-parent</artifactId>
-    <version>24.0.1.SP2</version>
+    <version>25.0.0.Beta1</version>
     <packaging>pom</packaging>
     <name>WildFly legacy Galleon feature-pack for Cloud parent</name>
   
@@ -40,7 +40,7 @@
     </licenses>
     
     <properties>
-        <version.org.wildfly>24.0.1.Final</version.org.wildfly>
+        <version.org.wildfly>25.0.0.Beta1</version.org.wildfly>
         <version.org.wildfly.galleon-plugins>5.2.0.Final</version.org.wildfly.galleon-plugins>
     </properties>
 

--- a/wildfly-cloud-legacy-galleon-pack/release/pom.xml
+++ b/wildfly-cloud-legacy-galleon-pack/release/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-cloud-legacy-galleon-pack-parent</artifactId>
-        <version>24.0.1.SP2</version>
+        <version>25.0.0.Beta1</version>
     </parent>
     <artifactId>wildfly-cloud-legacy-galleon-pack-release</artifactId>
     <packaging>pom</packaging>

--- a/wildfly-modules/jboss/container/wildfly/base/module.yaml
+++ b/wildfly-modules/jboss/container/wildfly/base/module.yaml
@@ -5,9 +5,9 @@ description: Module to setup WildFly env
 
 envs:
 - name: "WILDFLY_VERSION"
-  value: "24.0.1.Final"
+  value: "25.0.0.Beta1"
 - name:  WILDFLY_CLOUD_LEGACY_GALLEON_PACK_VERSION
-  value: "24.0.1.SP2"
+  value: "25.0.0.Beta1"
 - name: "CLI_GRACEFUL_SHUTDOWN"
   example: "true"
   description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."

--- a/wildfly-modules/tests/features/basic.feature
+++ b/wildfly-modules/tests/features/basic.feature
@@ -10,7 +10,7 @@ Feature: Wildfly basic tests
        | variable       | value           |
        | ADMIN_USERNAME | kabir           |
        | ADMIN_PASSWORD | pass            |
-    Then XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value ManagementRealm on XPath //*[local-name()='http-interface']/@security-realm
+    Then XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value management-http-authentication on XPath //*[local-name()='http-interface']/@http-authentication-factory
     And file /opt/wildfly/standalone/configuration/mgmt-users.properties should contain kabir
 
   Scenario: Add admin user to standard configuration, galleon s2i
@@ -20,7 +20,7 @@ Feature: Wildfly basic tests
        | ADMIN_PASSWORD           | pass            |
        | GALLEON_PROVISION_LAYERS | jaxrs-server     |
     Then container log should contain WFLYSRV0025
-    Then XML file /opt/wildfly/standalone/configuration/standalone.xml should have 0 elements on XPath  //*[local-name()='http-interface'][@security-realm="ManagementRealm"]
+    Then XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value management-http-authentication on XPath //*[local-name()='http-interface']/@http-authentication-factory
     And file /opt/wildfly/standalone/configuration/mgmt-users.properties should contain kabir
 
   Scenario: Make the Access Log Valve configurable

--- a/wildfly-modules/tests/features/https.feature
+++ b/wildfly-modules/tests/features/https.feature
@@ -1,31 +1,6 @@
 @wildfly/wildfly-centos7
 Feature: Check HTTPS configuration
 
-  Scenario: Configure HTTPS
-    When container is started with env
-      | variable                           | value                       |
-      | HTTPS_PASSWORD                 | p@ssw0rd                    |
-      | HTTPS_KEYSTORE_DIR             | /opt/wildfly                    |
-      | HTTPS_KEYSTORE                 | keystore.jks                |
-    Then XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value /opt/wildfly/keystore.jks on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@path
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value p@ssw0rd on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@keystore-password
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@name
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@socket-binding
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value ApplicationRealm on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@security-realm
-  
-  Scenario: Configure HTTPS, galleon s2i
-    Given s2i build git://github.com/openshift/openshift-jee-sample from . with env and true using master
-      | variable                           | value                       |
-      | GALLEON_PROVISION_LAYERS           | cloud-server   |
-      | HTTPS_PASSWORD                 | p@ssw0rd                    |
-      | HTTPS_KEYSTORE_DIR             | /opt/wildfly                    |
-      | HTTPS_KEYSTORE                 | keystore.jks                |
-    Then XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value /opt/wildfly/keystore.jks on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@path
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value p@ssw0rd on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@keystore-password
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@name
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@socket-binding
-    And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value ApplicationRealm on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@security-realm
-
   Scenario: Use Elytron for HTTPS
     When container is started with env
       | variable                      | value                       |
@@ -33,7 +8,6 @@ Feature: Check HTTPS configuration
       | HTTPS_KEYSTORE_DIR            | /opt/wildfly                    |
       | HTTPS_KEYSTORE                | keystore.jks                |
       | HTTPS_KEYSTORE_TYPE           | JKS                         |
-      | CONFIGURE_ELYTRON_SSL         | true                        |
     Then container log should contain WFLYSRV0025
     Then XML file /opt/wildfly/standalone/configuration/standalone.xml should have 0 elements on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']
     And XML file /opt/wildfly/standalone/configuration/standalone.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@name
@@ -50,7 +24,6 @@ Feature: Check HTTPS configuration
       | HTTPS_KEYSTORE_DIR            | /opt/wildfly                    |
       | HTTPS_KEYSTORE                | keystore.jks                |
       | HTTPS_KEYSTORE_TYPE           | JKS                         |
-      | CONFIGURE_ELYTRON_SSL         | true                        |
       | GALLEON_PROVISION_LAYERS      | cloud-server                |
     Then container log should contain WFLYSRV0025
     Then XML file /opt/wildfly/standalone/configuration/standalone.xml should have 0 elements on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']


### PR DESCRIPTION
* Upgrade to WildFly 25 Beta
* Updated default config and removed layer removed from WildFly 25 Beta
* Updated cloud feature-pack to not reference removed content
* Updated behave tests in relation with legacy security removal
* Tagged (in README) keycloak galleon layer and env variable "deprecated" (although we don't have yet a replacement strategy).
