### PR TITLE
Keycloak v2 and OIDC support

### DIFF
--- a/test/test-app-advanced-extensions/pom.xml
+++ b/test/test-app-advanced-extensions/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
   

--- a/test/test-app-clustering/pom.xml
+++ b/test/test-app-clustering/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
     

--- a/test/test-app-default-config/pom.xml
+++ b/test/test-app-default-config/pom.xml
@@ -35,7 +35,7 @@
     </licenses>
     <properties>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
     <build>

--- a/test/test-app-ejb/pom.xml
+++ b/test/test-app-ejb/pom.xml
@@ -17,7 +17,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <jakarta.jakartaee-api.version>8.0.0</jakarta.jakartaee-api.version>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
 

--- a/test/test-app-elytron-oidc-client-legacy/pom.xml
+++ b/test/test-app-elytron-oidc-client-legacy/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>SampleApp</groupId>
+    <artifactId>SampleApp</artifactId>
+    <version>1.0</version>
+    <packaging>war</packaging>
+
+    <name>WildFly Elytron OIDC client</name>
+    <description>An application secured with Elytron oidc client example</description>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>oidc-webapp-legacy</finalName>
+    </build>
+
+</project>

--- a/test/test-app-elytron-oidc-client-legacy/src/main/java/org/wildfly/security/examples/SecuredServlet.java
+++ b/test/test-app-elytron-oidc-client-legacy/src/main/java/org/wildfly/security/examples/SecuredServlet.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Principal;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpMethodConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A simple secured HTTP servlet.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@WebServlet("/secured")
+@ServletSecurity(httpMethodConstraints = { @HttpMethodConstraint(value = "GET", rolesAllowed = { "Users" }) })
+public class SecuredServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (PrintWriter writer = resp.getWriter()) {
+            writer.println("<html>");
+            writer.println("  <head><title>Secured Servlet</title></head>");
+            writer.println("  <body>");
+            writer.println("    <h1>Secured Servlet</h1>");
+            writer.println("    <p>");
+            writer.print(" Current Principal '");
+            Principal user = req.getUserPrincipal();
+            writer.print(user != null ? user.getName() : "NO AUTHENTICATED USER");
+            writer.print("'");
+            writer.println("    </p>");
+            writer.println("  </body>");
+            writer.println("</html>");
+        }
+    }
+
+}

--- a/test/test-app-elytron-oidc-client-legacy/src/main/webapp/WEB-INF/web.xml
+++ b/test/test-app-elytron-oidc-client-legacy/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   metadata-complete="false">
+
+    <login-config>
+        <auth-method>OIDC</auth-method>
+    </login-config>
+
+</web-app>

--- a/test/test-app-elytron-oidc-client-legacy/src/main/webapp/index.html
+++ b/test/test-app-elytron-oidc-client-legacy/src/main/webapp/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <h2>Hello World!</h2>
+    <a href="./secured">Access Secured Servlet</a>
+  </body>
+</html>

--- a/test/test-app-elytron-oidc-client/pom.xml
+++ b/test/test-app-elytron-oidc-client/pom.xml
@@ -1,0 +1,77 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>SampleApp</groupId>
+    <artifactId>SampleApp</artifactId>
+    <version>1.0</version>
+    <packaging>war</packaging>
+
+    <name>WildFly Elytron OIDC client</name>
+    <description>An application secured with Elytron oidc client example</description>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly>25.0.1.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- When built in OpenShift the 'openshift' profile will be used when invoking mvn. -->
+            <!-- Use this profile for any OpenShift specific customization your app will need. -->
+            <!-- By default that is to put the resulting archive into the 'deployments' folder. -->
+            <!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
+            <id>openshift</id>
+            <build>
+                <finalName>oidc-webapp</finalName>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.wildfly.plugin}</version>
+                        <configuration>
+                            <!-- some tests check for the provisioned galleon layers -->
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <feature-packs>
+                                <feature-pack>
+                                    <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                                </feature-pack>
+                                <feature-pack>
+                                    <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                                </feature-pack>
+                            </feature-packs>
+                            <layers>
+                                <layer>cloud-server</layer>
+                                <layer>elytron-oidc-client</layer>
+                            </layers>
+                            <galleon-options>
+                                <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                            </galleon-options>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/test/test-app-elytron-oidc-client/src/main/java/org/wildfly/security/examples/SecuredServlet.java
+++ b/test/test-app-elytron-oidc-client/src/main/java/org/wildfly/security/examples/SecuredServlet.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Principal;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpMethodConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A simple secured HTTP servlet.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@WebServlet("/secured")
+@ServletSecurity(httpMethodConstraints = { @HttpMethodConstraint(value = "GET", rolesAllowed = { "Users" }) })
+public class SecuredServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (PrintWriter writer = resp.getWriter()) {
+            writer.println("<html>");
+            writer.println("  <head><title>Secured Servlet</title></head>");
+            writer.println("  <body>");
+            writer.println("    <h1>Secured Servlet</h1>");
+            writer.println("    <p>");
+            writer.print(" Current Principal '");
+            Principal user = req.getUserPrincipal();
+            writer.print(user != null ? user.getName() : "NO AUTHENTICATED USER");
+            writer.print("'");
+            writer.println("    </p>");
+            writer.println("  </body>");
+            writer.println("</html>");
+        }
+    }
+
+}

--- a/test/test-app-elytron-oidc-client/src/main/webapp/WEB-INF/web.xml
+++ b/test/test-app-elytron-oidc-client/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   metadata-complete="false">
+
+    <login-config>
+        <auth-method>OIDC</auth-method>
+    </login-config>
+
+</web-app>

--- a/test/test-app-elytron-oidc-client/src/main/webapp/index.html
+++ b/test/test-app-elytron-oidc-client/src/main/webapp/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <h2>Hello World!</h2>
+    <a href="./secured">Access Secured Servlet</a>
+  </body>
+</html>

--- a/test/test-app-extension/pom.xml
+++ b/test/test-app-extension/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
   

--- a/test/test-app-extension2/pom.xml
+++ b/test/test-app-extension2/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
   

--- a/test/test-app-jpa2lc/pom.xml
+++ b/test/test-app-jpa2lc/pom.xml
@@ -17,7 +17,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <jakarta.jakartaee-api.version>8.0.0</jakarta.jakartaee-api.version>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
 

--- a/test/test-app-keycloak-legacy/.s2i/environment
+++ b/test/test-app-keycloak-legacy/.s2i/environment
@@ -1,0 +1,1 @@
+CUSTOM_INSTALL_DIRECTORIES=install-keycloak/target/keycloak-oidc,install-keycloak/target/keycloak-saml

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/README.md
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/README.md
@@ -1,0 +1,28 @@
+You need to create a client in Keycloak. The configuration options when creating the client should be:
+
+Settings
+-----------
+* Client ID: app-profile-jee-saml
+* Enabled: ON
+* Consent Required: OFF
+* direct-grants-only: OFF
+* Client Protocol: saml
+* Include AuthnStatement: ON
+* Sign Documents: OFF
+* Sign Assertions: OFF
+* Encrypt Assertions: OFF
+* Client Signature Required: OFF
+* Force POST Binding: OFF
+* Front Channel Logout: OFF
+* Force Name ID Format: OFF
+* Name ID Format: username
+* Root URL: <blank>
+* Valid Redirect URIs: http://localhost:8080/app-profile-jee-saml/*
+* Base URL: http://localhost:8080/app-profile-jee-saml/
+* Master SAML Processing URL: http://localhost:8080/app-profile-jee-saml/saml
+
+Mappers
+------------
+Add all builtin mappers
+
+Then, build the WAR with Maven and install as per the Adapter configuration for your server as described in the Keycloak documentation.

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/pom.xml
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.keycloak.quickstart</groupId>
+        <artifactId>keycloak-quickstart-parent</artifactId>
+        <version>0.5-SNAPSHOT</version>
+    </parent>
+    
+    <groupId>org.keycloak.quickstart</groupId>
+    <artifactId>keycloak-quickstart-app-profile-jee-saml</artifactId>
+    <version>0.5-SNAPSHOT</version>
+
+    <name>Keycloak Quickstart App Profile JEE SAML</name>
+    <description/>
+
+    <packaging>war</packaging>
+
+    <properties>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-api-public</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- <dependency>
+            <groupId>org.keycloak.quickstart</groupId>
+            <artifactId>keycloak-quickstart-app-profile-jee</artifactId>
+            <type>war</type>
+            <version>${project.version}</version>
+        </dependency> -->
+    </dependencies>
+
+    <build>
+        <finalName>app-profile-jee-saml</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    </configuration>
+		    </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.keycloak.quickstart.profilejee;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.keycloak.adapters.saml.SamlDeploymentContext;
+import org.keycloak.adapters.saml.SamlPrincipal;
+import org.keycloak.adapters.saml.SamlSession;
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.constants.ServiceUrlConstants;
+
+/**
+ * Controller simplifies access to the server environment from the JSP.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2015 Red Hat Inc.
+ */
+public class Controller {
+
+    public String getFirstName(HttpServletRequest req) {
+        return getFriendlyAttrib(req, "givenName");
+    }
+
+    public String getLastName(HttpServletRequest req) {
+        return getFriendlyAttrib(req, "surname");
+    }
+
+    public String getEmail(HttpServletRequest req) {
+        return getFriendlyAttrib(req, "email");
+    }
+
+    public String getUsername(HttpServletRequest req) {
+        return req.getUserPrincipal().getName();
+    }
+
+    private String getFriendlyAttrib(HttpServletRequest req, String attribName) {
+    	SamlPrincipal principal = getAccount(req);
+        return principal.getFriendlyAttribute(attribName);
+    }
+
+    private SamlPrincipal getAccount(HttpServletRequest req) {
+    	SamlPrincipal principal = (SamlPrincipal)req.getUserPrincipal();
+        return principal;
+    }
+
+    public boolean isLoggedIn(HttpServletRequest req) {
+        return getAccount(req) != null;
+    }
+
+    public String getAccountUri(HttpServletRequest req) {
+        String serverPath = findKeycloakServerPath(req);
+        String realm = findRealmName(req);
+        return KeycloakUriBuilder.fromUri(serverPath).path(ServiceUrlConstants.ACCOUNT_SERVICE_PATH)
+                .queryParam("referrer", "app-profile-jee-saml").build(realm).toString();
+    }
+
+    // HACK: This is a really bad way to find the realm name, but I can't
+    //       figure out a better way to do it with the SAML adapter.  It parses
+    //       the URL specified in keycloak-saml.xml
+    private String findRealmName(HttpServletRequest req) {
+        String bindingUrl = getBindingUrl(req);
+        // bindingUrl looks like http://localhost:8080/auth/realms/master/protocol/saml
+        int beginIndex = bindingUrl.indexOf("/realms/") + "/realms/".length();
+        return bindingUrl.substring(beginIndex, bindingUrl.indexOf('/', beginIndex));
+    }
+
+    private String findKeycloakServerPath(HttpServletRequest req) {
+        String bindingUrl = getBindingUrl(req);
+        // bindingUrl looks like http://localhost:8080/auth/realms/master/protocol/saml
+        return bindingUrl.substring(0, bindingUrl.indexOf("/auth")) + "/auth";
+    }
+
+    private String getBindingUrl(HttpServletRequest req) {
+        SamlDeploymentContext ctx = (SamlDeploymentContext)req.getServletContext().getAttribute(SamlDeploymentContext.class.getName());
+        return ctx.resolveDeployment(null).getIDP().getSingleSignOnService().getRequestBindingUrl();
+    }
+
+}

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/WEB-INF/keycloak-saml.xml
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/WEB-INF/keycloak-saml.xml
@@ -1,0 +1,30 @@
+<keycloak-saml-adapter>
+    <SP entityID="app-profile-jee-saml"
+        sslPolicy="NONE"
+        nameIDPolicyFormat="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+        logoutPage="/index.jsp"
+        forceAuthentication="false">
+        <PrincipalNameMapping policy="FROM_NAME_ID"/>
+        <RoleIdentifiers>
+            <Attribute name="Role"/>
+        </RoleIdentifiers>
+        <IDP entityID="idp">
+            <SingleSignOnService signRequest="false"
+                                 validateResponseSignature="false"
+                                 requestBinding="POST"
+                                 bindingUrl="http://localhost:8080/auth/realms/master/protocol/saml"
+                    />
+
+            <SingleLogoutService
+                    validateRequestSignature="false"
+                    validateResponseSignature="false"
+                    signRequest="false"
+                    signResponse="false"
+                    requestBinding="POST"
+                    responseBinding="POST"
+                    postBindingUrl="http://localhost:8080/auth/realms/master/protocol/saml"
+                    redirectBindingUrl="http://localhost:8080/auth/realms/master/protocol/saml"
+                    />
+        </IDP>
+     </SP>
+</keycloak-saml-adapter>

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/WEB-INF/web.xml
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <module-name>app-profile-jee-saml</module-name>
+
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/profile.jsp</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/saml</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>KEYCLOAK-SAML</auth-method>
+    </login-config>
+
+    <security-role>
+        <role-name>user</role-name>
+    </security-role>
+
+</web-app>

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/index.jsp
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/index.jsp
@@ -1,0 +1,46 @@
+<%-- 
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+--%>
+
+<%@page contentType="text/html" pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+        <title>Keycloak Example App</title>
+
+        <link rel="stylesheet" type="text/css" href="styles.css"/>
+    </head>
+    <body>
+        <jsp:useBean id="controller" class="org.keycloak.quickstart.profilejee.Controller" scope="request"/>
+        
+        <c:set var="isLoggedIn" value="<%=controller.isLoggedIn(request)%>"/>
+        <c:if test="${isLoggedIn}">
+            <c:redirect url="profile.jsp"/>
+        </c:if>
+
+        <div class="wrapper" id="welcome">
+            <div class="menu">
+                <button onclick="location.href = 'profile.jsp'" type="button">Login</button>
+            </div>
+
+            <div class="content">
+                <div class="message">Please login</div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/profile.jsp
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/profile.jsp
@@ -1,0 +1,62 @@
+<%-- 
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+--%>
+
+<%@page contentType="text/html" pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+        <title>Keycloak SAML Example App</title>
+        <link rel="stylesheet" type="text/css" href="styles.css"/>
+    </head>
+    <body>
+        <jsp:useBean id="controller" class="org.keycloak.quickstart.profilejee.Controller" scope="request"/>
+        <c:set var="accountUri" value="<%=controller.getAccountUri(request)%>"/>
+        <c:set var="req" value="<%=request%>"/>
+
+        <div class="wrapper" id="profile">
+            <div class="menu">
+                <button onclick="location.href = '?GLO=true'" type="button">Logout</button>
+                <button onclick="location.href = '${accountUri}'" type="button">Account</button>
+            </div>
+
+            <div class="content">
+                <div id="profile-content" class="message">
+                    <table cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="label">First name</td>
+                            <td><span id="firstName">${controller.getFirstName(req)}</span></td>
+                        </tr>
+                        <tr class="even">
+                            <td class="label">Last name</td>
+                            <td><span id="lastName">${controller.getLastName(req)}</span></td>
+                        </tr>
+                        <tr>
+                            <td class="label">Username</td>
+                            <td><span id="username">${controller.getUsername(req)}</span></td>
+                        </tr>
+                        <tr class="even">
+                            <td class="label">Email</td>
+                            <td><span id="email">${controller.getEmail(req)}</span></td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/styles.css
+++ b/test/test-app-keycloak-legacy/app-profile-jee-saml/src/main/webapp/styles.css
@@ -1,0 +1,101 @@
+
+body {
+    background-color: #333;
+    font-family: sans-serif;
+    font-size: 30px;
+}
+
+button {
+    font-family: sans-serif;
+    font-size: 30px;
+    width: 200px;
+
+    background-color: #0085cf;
+    background-image: linear-gradient(to bottom, #00a8e1 0%, #0085cf 100%);
+    background-repeat: repeat-x;
+
+    border: 2px solid #ccc;
+    color: #fff;
+    -webkit-border-radius: 30px;
+
+    text-transform: uppercase;
+
+    -webkit-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    -moz-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+}
+
+button:hover {
+    background-color: #006ba6;
+    background-image: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+}
+
+hr {
+    border: none;
+    background-color: #eee;
+    height: 10px;
+}
+
+.menu {
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.content {
+    background-color: #eee;
+    border: 1px solid #ccc;
+    padding: 10px;
+    -webkit-border-radius: 10px;
+
+    -webkit-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    -moz-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+}
+
+.content .message {
+    padding: 10px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    font-size: 40px;
+    -webkit-border-radius: 10px;
+}
+
+#token .content .message {
+    font-size: 20px;
+    overflow: scroll;
+    padding: 5px;
+    white-space: pre;
+    text-transform: none;
+}
+
+.wrapper {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    bottom: 10px;
+    right: 10px;
+}
+
+.error {
+    color: #a21e22;
+}
+
+table {
+   width: 100%; 
+}
+
+tr.even {
+    background-color: #eee;
+}
+
+td {
+    padding: 5px;
+}
+
+td.label {
+    font-weight: bold;
+    width: 250px;
+}

--- a/test/test-app-keycloak-legacy/app-profile-jee/README.md
+++ b/test/test-app-keycloak-legacy/app-profile-jee/README.md
@@ -1,0 +1,10 @@
+You need to create a client in Keycloak. The configuration options when creating the client should be:
+
+* Client ID: You choose
+* Access Type: confidential
+* Root URL: Root URL for where you're hosting the application (for example http://localhost:8080)
+* Valie Redirect URIs: /app-profile-jee/*
+* Base URL: /app-profile-jee/
+* Admin URL: /app-profile-jee/
+
+Then, build the WAR with Maven and install as per the Adapter configuration for your server as described in the Keycloak documentation.

--- a/test/test-app-keycloak-legacy/app-profile-jee/pom.xml
+++ b/test/test-app-keycloak-legacy/app-profile-jee/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.keycloak.quickstart</groupId>
+        <artifactId>keycloak-quickstart-parent</artifactId>
+        <version>0.5-SNAPSHOT</version>
+    </parent>
+    
+    <groupId>org.keycloak.quickstart</groupId>
+    <artifactId>keycloak-quickstart-app-profile-jee</artifactId>
+    <version>0.5-SNAPSHOT</version>
+
+    <name>Keycloak Quickstart App Profile JEE</name>
+    <description/>
+
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>app-profile-jee</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/test-app-keycloak-legacy/app-profile-jee/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
+++ b/test/test-app-keycloak-legacy/app-profile-jee/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.keycloak.quickstart.profilejee;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import org.keycloak.KeycloakSecurityContext;
+import org.keycloak.adapters.AdapterDeploymentContext;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.constants.ServiceUrlConstants;
+import org.keycloak.representations.IDToken;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * Controller simplifies access to the server environment from the JSP.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2015 Red Hat Inc.
+ */
+public class Controller {
+
+    public void handleLogout(HttpServletRequest req) throws ServletException {
+        if (req.getParameter("logout") != null) {
+            req.logout();
+        }
+    }
+
+    public boolean isLoggedIn(HttpServletRequest req) {
+        return getSession(req) != null;
+    }
+
+    public boolean showToken(HttpServletRequest req) {
+        return req.getParameter("showToken") != null;
+    }
+
+    public IDToken getIDToken(HttpServletRequest req) {
+        return getSession(req).getIdToken();
+    }
+
+    public String getAccountUri(HttpServletRequest req) {
+        KeycloakSecurityContext session = getSession(req);
+        String baseUrl = getAuthServerBaseUrl(req);
+        String realm = session.getRealm();
+        return KeycloakUriBuilder.fromUri(baseUrl).path(ServiceUrlConstants.ACCOUNT_SERVICE_PATH)
+                .queryParam("referrer", "app-profile-jee").build(realm).toString();
+
+    }
+
+    private String getAuthServerBaseUrl(HttpServletRequest req) {
+        AdapterDeploymentContext deploymentContext = (AdapterDeploymentContext) req.getServletContext().getAttribute(AdapterDeploymentContext.class.getName());
+        KeycloakDeployment deployment = deploymentContext.resolveDeployment(null);
+        return deployment.getAuthServerBaseUrl();
+    }
+
+    public String getTokenString(HttpServletRequest req) throws IOException {
+        return JsonSerialization.writeValueAsPrettyString(getIDToken(req));
+    }
+
+    private KeycloakSecurityContext getSession(HttpServletRequest req) {
+        return (KeycloakSecurityContext) req.getAttribute(KeycloakSecurityContext.class.getName());
+    }
+}

--- a/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/WEB-INF/web.xml
+++ b/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <module-name>app-profile-jee</module-name>
+
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/profile.jsp</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>KEYCLOAK</auth-method>
+    </login-config>
+
+    <security-role>
+        <role-name>user</role-name>
+    </security-role>
+
+</web-app>

--- a/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/index.jsp
+++ b/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/index.jsp
@@ -1,0 +1,47 @@
+<%-- 
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+--%>
+
+<%@page contentType="text/html" pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+        <title>Keycloak Example App</title>
+
+        <link rel="stylesheet" type="text/css" href="styles.css"/>
+    </head>
+    <body>
+        <jsp:useBean id="controller" class="org.keycloak.quickstart.profilejee.Controller" scope="request"/>
+        <% controller.handleLogout(request); %>
+        
+        <c:set var="isLoggedIn" value="<%=controller.isLoggedIn(request)%>"/>
+        <c:if test="${isLoggedIn}">
+            <c:redirect url="profile.jsp"/>
+        </c:if>
+
+        <div class="wrapper" id="welcome">
+            <div class="menu">
+                <button onclick="location.href = 'profile.jsp'" type="button">Login</button>
+            </div>
+
+            <div class="content">
+                <div class="message">Please login</div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/profile.jsp
+++ b/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/profile.jsp
@@ -1,0 +1,79 @@
+<%-- 
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+--%>
+
+<%@page contentType="text/html" pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+        <title>Keycloak Example App</title>
+        <link rel="stylesheet" type="text/css" href="styles.css"/>
+    </head>
+    <body>
+        <jsp:useBean id="controller" class="org.keycloak.quickstart.profilejee.Controller" scope="request"/>
+        <c:set var="idToken" value="<%=controller.getIDToken(request)%>"/>
+        <c:set var="tokenString" value="<%=controller.getTokenString(request)%>"/>
+        <c:set var="accountUri" value="<%=controller.getAccountUri(request)%>"/>
+        <c:set var="showToken" value="<%=controller.showToken(request)%>"/>
+
+        <div class="wrapper" id="profile">
+            <div class="menu">
+                <c:if test="${!showToken}">
+                    <button onclick="location.href = 'profile.jsp?showToken=true'">Token</button>
+                </c:if>
+                <c:if test="${showToken}">
+                    <button onclick="location.href = 'profile.jsp'">Profile</button>
+                </c:if>
+                <button onclick="location.href = 'index.jsp?logout=true'" type="button">Logout</button>
+                <button onclick="location.href = '${accountUri}'" type="button">Account</button>
+            </div>
+
+            <c:if test="${showToken}">
+                <div class="content">
+                    <div id="token-content" class="message">${tokenString}</div>
+                   <!-- <script>document.write(JSON.stringify(JSON.parse('${tokenString}'), null, '  '));</script>-->
+                </div>
+            </c:if>
+
+            <c:if test="${!showToken}">
+                <div class="content">
+                    <div id="profile-content" class="message">
+                        <table cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td class="label">First name</td>
+                                <td><span id="firstName">${idToken.givenName}</span></td>
+                            </tr>
+                            <tr class="even">
+                                <td class="label">Last name</td>
+                                <td><span id="lastName">${idToken.familyName}</span></td>
+                            </tr>
+                            <tr>
+                                <td class="label">Username</td>
+                                <td><span id="username">${idToken.preferredUsername}</span></td>
+                            </tr>
+                            <tr class="even">
+                                <td class="label">Email</td>
+                                <td><span id="email">${idToken.email}</span></td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </c:if>
+        </div>
+    </body>
+</html>

--- a/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/styles.css
+++ b/test/test-app-keycloak-legacy/app-profile-jee/src/main/webapp/styles.css
@@ -1,0 +1,101 @@
+
+body {
+    background-color: #333;
+    font-family: sans-serif;
+    font-size: 30px;
+}
+
+button {
+    font-family: sans-serif;
+    font-size: 30px;
+    width: 200px;
+
+    background-color: #0085cf;
+    background-image: linear-gradient(to bottom, #00a8e1 0%, #0085cf 100%);
+    background-repeat: repeat-x;
+
+    border: 2px solid #ccc;
+    color: #fff;
+    -webkit-border-radius: 30px;
+
+    text-transform: uppercase;
+
+    -webkit-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    -moz-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+}
+
+button:hover {
+    background-color: #006ba6;
+    background-image: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+}
+
+hr {
+    border: none;
+    background-color: #eee;
+    height: 10px;
+}
+
+.menu {
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.content {
+    background-color: #eee;
+    border: 1px solid #ccc;
+    padding: 10px;
+    -webkit-border-radius: 10px;
+
+    -webkit-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    -moz-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+}
+
+.content .message {
+    padding: 10px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    font-size: 40px;
+    -webkit-border-radius: 10px;
+}
+
+#token .content .message {
+    font-size: 20px;
+    overflow: scroll;
+    padding: 5px;
+    white-space: pre;
+    text-transform: none;
+}
+
+.wrapper {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    bottom: 10px;
+    right: 10px;
+}
+
+.error {
+    color: #a21e22;
+}
+
+table {
+   width: 100%; 
+}
+
+tr.even {
+    background-color: #eee;
+}
+
+td {
+    padding: 5px;
+}
+
+td.label {
+    font-weight: bold;
+    width: 250px;
+}

--- a/test/test-app-keycloak-legacy/install-keycloak/pom.xml
+++ b/test/test-app-keycloak-legacy/install-keycloak/pom.xml
@@ -1,0 +1,80 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Keycloak Quickstart Install keycloak adapters</name>
+    <description>Keycloak Quickstart Install keycloak adapters</description>
+    <groupId>org.keycloak.quickstart</groupId>
+    <artifactId>keycloak-quickstart-install</artifactId>
+    <version>0.5-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <url>http://keycloak.org</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/keycloak/keycloak-examples.git</connection>
+        <developerConnection>scm:git:git@github.com:keycloak/keycloak-examples.git</developerConnection>
+        <url>https://github.com/keycloak/keycloak-examples/tree/master</url>
+    </scm>
+
+    <build>
+        <pluginManagement>
+            <plugins>                
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.wildfly.plugin}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>   
+            </plugins>             
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-files</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <mkdir dir="${project.build.directory}"/>
+                                <get src="https://github.com/keycloak/keycloak/releases/download/15.0.2/keycloak-oidc-wildfly-adapter-15.0.2.zip"
+                                     dest="${project.build.directory}/keycloak-oidc.zip"
+                                     verbose="true"
+                                     usetimestamp="true"/>
+                                <exec executable="unzip" failonerror="true">
+                                    <arg value="${project.build.directory}/keycloak-oidc.zip"/>
+                                    <arg value="-d"/>
+                                    <arg value="${project.build.directory}/keycloak-oidc"/>
+                                </exec>
+                                <get src="https://github.com/keycloak/keycloak/releases/download/15.0.2/keycloak-saml-wildfly-adapter-15.0.2.zip"
+                                     dest="${project.build.directory}/keycloak-saml.zip"
+                                     verbose="true"
+                                     usetimestamp="true"/>
+                                <exec executable="unzip" failonerror="true">
+                                    <arg value="${project.build.directory}/keycloak-saml.zip"/>
+                                    <arg value="-d"/>
+                                    <arg value="${project.build.directory}/keycloak-saml"/>
+                                </exec>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/test-app-keycloak-legacy/pom.xml
+++ b/test/test-app-keycloak-legacy/pom.xml
@@ -1,0 +1,129 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Keycloak Quickstart Parent</name>
+    <description>Keycloak Quickstart Parent</description>
+    <groupId>org.keycloak.quickstart</groupId>
+    <artifactId>keycloak-quickstart-parent</artifactId>
+    <version>0.5-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <version.resteasy>3.0.12.Final</version.resteasy>
+        <version.wildfly.plugin>1.0.1.Final</version.wildfly.plugin>
+        <version.keycloak>13.0.0</version.keycloak>
+        <version.httpclient>4.5.13</version.httpclient>
+        <version.jboss.servlet-api>1.0.2.Final</version.jboss.servlet-api>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <url>http://keycloak.org</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/keycloak/keycloak-examples.git</connection>
+        <developerConnection>scm:git:git@github.com:keycloak/keycloak-examples.git</developerConnection>
+        <url>https://github.com/keycloak/keycloak-examples/tree/master</url>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>jboss-releases-repository</id>
+            <name>JBoss Releases Repository</name>
+            <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <developers>
+    </developers>
+
+    <contributors>
+    </contributors>
+
+    <modules>
+        <module>install-keycloak</module>
+        <module>app-profile-jee</module>
+        <module>app-profile-jee-saml</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>jaxrs-api</artifactId>
+                <version>${version.resteasy}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>${version.jboss.servlet-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-core</artifactId>
+                <version>${version.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-core</artifactId>
+                <version>${version.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-saml-adapter-api-public</artifactId>
+                <version>${version.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-spi</artifactId>
+                <version>${version.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-saml-adapter-core</artifactId>
+                <version>${version.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-spi</artifactId>
+                <version>${version.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${version.httpclient}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>jboss</id>
+            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <pluginManagement>
+            <plugins>                
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.wildfly.plugin}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>   
+            </plugins>             
+        </pluginManagement>
+    </build>
+</project>

--- a/test/test-app-postgres/pom.xml
+++ b/test/test-app-postgres/pom.xml
@@ -32,7 +32,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
         <version.wildfly.datasources.galleon.pack>2.0.5.Final</version.wildfly.datasources.galleon.pack>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
   

--- a/test/test-app-postgresql-mysql/pom.xml
+++ b/test/test-app-postgresql-mysql/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.datasources.galleon.pack>2.0.5.Final</version.wildfly.datasources.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>

--- a/test/test-app-settings/pom.xml
+++ b/test/test-app-settings/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
   

--- a/test/test-app/pom.xml
+++ b/test/test-app/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.wildfly>25.0.1.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha3</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>1.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>3.0.0.Alpha2</version.wildfly.plugin>
     </properties>
     

--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -31,6 +31,8 @@ envs:
       value: *imgVersion
     - name: JBOSS_HOME
       value: /opt/server
+    - name: SSO_DEFAULT_PROVIDER_NAME
+      value: keycloak
 ports:
     - value: 8080
 modules:
@@ -64,6 +66,7 @@ packages:
   install:
           # required by launch scripts
           - hostname
+          - jq
 run:
       user: 185
       cmd:

--- a/wildfly-builder-image/tests/features/legacy-elytron.feature
+++ b/wildfly-builder-image/tests/features/legacy-elytron.feature
@@ -5,7 +5,7 @@ Scenario: Build elytron app
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-web-security with env and true using master
        | variable                   | value       |
        | GALLEON_PROVISION_LAYERS | datasources-web-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha2 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha4 |
      Then container log should contain WFLYSRV0025
 
  Scenario: check Elytron configuration with elytron core realms security domain fail

--- a/wildfly-builder-image/tests/features/legacy-s2i.feature
+++ b/wildfly-builder-image/tests/features/legacy-s2i.feature
@@ -16,7 +16,7 @@ Scenario: Test preconfigure.sh
       | variable                             | value         |
       | TEST_EXTENSION_PRE_ADD_PROPERTY      | foo           |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha2 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha4 |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served
@@ -28,7 +28,7 @@ Scenario: Test preconfigure.sh
   Scenario: Test default cloud config
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using master
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha2 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha4 |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served
@@ -52,7 +52,7 @@ Scenario: Test preconfigure.sh
   Scenario: Test cloud-server, exclude jaxrs
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using master
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha2 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha4 |
       | GALLEON_PROVISION_LAYERS             | cloud-server,-jaxrs  |
     Then container log should contain WFLYSRV0025
     And check that page is served
@@ -79,7 +79,7 @@ Scenario: Test external driver created during s2i.
       | variable                     | value                                                       |
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha2 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha4 |
     Then container log should contain WFLYSRV0025
     And check that page is served
       | property | value |
@@ -96,7 +96,7 @@ Scenario: Test external driver created during s2i.
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | DISABLE_BOOT_SCRIPT_INVOKER  | true |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha2 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:25.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.0.0.Alpha4 |
     Then container log should contain Configuring the server using embedded server
     Then container log should contain WFLYSRV0025
     And check that page is served

--- a/wildfly-runtime-image/image.yaml
+++ b/wildfly-runtime-image/image.yaml
@@ -23,7 +23,8 @@ envs:
       value: *imgVersion
     - name: JBOSS_HOME
       value: /opt/server
-
+    - name: SSO_DEFAULT_PROVIDER_NAME
+      value: keycloak
 ports:
     - value: 8080
 modules:
@@ -48,6 +49,7 @@ packages:
   install:
           # required by launch scripts
           - hostname
+          - jq
 
 run:
       user: 185


### PR DESCRIPTION
* Upgrade test apps to use cloud FP 1.0.0.Alpha4
* New test apps for oidc and keycloak
* builder and runtime images now install jq command line and set the default sso provider name env variable (needed when using SSO_* enbv variables with oidc native support).

NB: New behave tests to cover oidc and keycloak will come in another PR when this one is merged.
