### PR TITLE
Fix for Issue #265, Default location /usr/libexec/s2i is missing from…

### DIFF
--- a/wildfly-modules/s2i-wildfly/bash/configure.sh
+++ b/wildfly-modules/s2i-wildfly/bash/configure.sh
@@ -9,6 +9,9 @@ chown -R jboss:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/usr/local/s2i/*
 
+# Legacy location required by s2i tooling.
+ln -s /usr/local/s2i /usr/libexec/s2i
+
 pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd


### PR DESCRIPTION
… builder image