### PR TITLE
[V2] Rely on openjdk modules instead of cct_modules

### DIFF
--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -42,7 +42,7 @@ modules:
           - name: openjdk
             git:
               url: https://github.com/jboss-container-images/openjdk
-              ref: develop
+              ref: openjdk-containers-1.11
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules

--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -39,10 +39,10 @@ ports:
     - value: 8080
 modules:
       repositories:
-          - name: cct_module
+          - name: openjdk
             git:
-              url: https://github.com/jboss-openshift/cct_module
-              ref: 0.45.1
+              url: https://github.com/jboss-container-images/openjdk
+              ref: develop
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules
@@ -56,13 +56,13 @@ modules:
           - name: jboss.container.maven
             version: "8.2.3.6"
           - name: dynamic-resources
-          - name: jboss.container.maven.default
           - name: jboss.container.maven.s2i
+          - name: jboss.container.util.nss-wrapper
           # Remove this dependency to not support env variable based provisioning and legacy workflow
           # Put it prior to wildfly.s2i-wildfly module in case this last module overrides env variables.
           - name: jboss.container.wildfly.s2i.legacy
           - name: jboss.container.wildfly.s2i-wildfly.bash
-          
+
 packages:
   manager: microdnf
   install:

--- a/wildfly-builder-image/tests/features/vanilla-basic.feature
+++ b/wildfly-builder-image/tests/features/vanilla-basic.feature
@@ -40,7 +40,7 @@ Scenario: Zero port offset in galleon provisioned configuration with vanilla wil
 Scenario: Check default GC configuration
     When container integ- is started with env
     | variable  | value                      |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelGC\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
@@ -52,7 +52,7 @@ Scenario: Check default GC configuration
     When container integ- is started with env
        | variable                         | value  |
        | GC_MIN_HEAP_FREE_RATIO           | 5      |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelGC\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=5\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
@@ -63,7 +63,7 @@ Scenario: Check default GC configuration
     When container integ- is started with env
        | variable                         | value  |
        | GC_MAX_HEAP_FREE_RATIO           | 50     |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelGC\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=50\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
@@ -74,7 +74,7 @@ Scenario: Check default GC configuration
     When container integ- is started with env
        | variable                         | value  |
        | GC_TIME_RATIO                    | 5      |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelGC\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=5\s
@@ -85,7 +85,7 @@ Scenario: Check default GC configuration
     When container integ- is started with env
        | variable                         | value  |
        | GC_ADAPTIVE_SIZE_POLICY_WEIGHT   | 80     |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelGC\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
@@ -97,7 +97,7 @@ Scenario: Check default GC configuration
        | variable                 | value  |
        | GC_METASPACE_SIZE        | 60     |
        | GC_MAX_METASPACE_SIZE    | 120    |
-    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelGC\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
@@ -215,7 +215,7 @@ Scenario: Test to ensure that maven is run with -Djava.net.preferIPv4Stack=true 
     And run sh -c 'test -d /tmp/artifacts/m2/org && echo all good' in container and immediately check its output for all good
     And s2i build log should contain -Djava.net.preferIPv4Stack=true
     And s2i build log should contain -Dfoo=bar
-    And s2i build log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError
+    And s2i build log should contain -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError
 
 Scenario:  Override default launcher
     When container integ- is started with env

--- a/wildfly-modules/dynamic-resources/dynamic_resources.sh
+++ b/wildfly-modules/dynamic-resources/dynamic_resources.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+# For backward compatibility: CONTAINER_HEAP_PERCENT is old variable name
+JAVA_MAX_MEM_RATIO=${JAVA_MAX_MEM_RATIO:-$(echo "${CONTAINER_HEAP_PERCENT:-0.5}" "100" | awk '{ printf "%d", $1 * $2 }')}
+JAVA_INITIAL_MEM_RATIO=${JAVA_INITIAL_MEM_RATIO:-${INITIAL_HEAP_PERCENT:+$(echo "${INITIAL_HEAP_PERCENT}" "100" | awk '{ printf "%d", $1 * $2 }')}}
+
+function source_java_run_scripts() {
+    local java_scripts_dir="/opt/run-java"
+    # set CONTAINER_MAX_MEMORY and CONTAINER_CORE_LIMIT
+    source "${java_scripts_dir}/container-limits"
+    # load java options functions
+    source "${java_scripts_dir}/java-default-options"
+}
+
+source_java_run_scripts
+
+# deprecated, left for backward compatibility
+function get_heap_size {
+    echo $(max_memory)
+}
+
+# deprecated, left for backward compatibility
+get_initial_heap_size() {
+    local max_heap="$1"
+    echo "$max_heap" "${INITIAL_HEAP_PERCENT-1.0}" | awk '{ printf "%d", $1 * $2 }'
+}
+
+# deprecated, left for backward compatibility
+adjust_java_heap_settings() {
+    local java_scripts_dir="/opt/run-java"
+    
+    # nuke any hard-coded memory settings.  java-default-options won't add these
+    # if they're already specified
+    JAVA_OPTS="$(echo $JAVA_OPTS| sed -re 's/(-Xmx[^ ]*|-Xms[^ ]*)//g')"
+    local java_options=$(source "${java_scripts_dir}/java-default-options")
+    local max_heap=$(echo "${java_options}" | grep -Eo "\-Xmx[^ ]* ")
+    local initial_heap=$(echo "${java_options}" | grep -Eo "\-Xms[^ ]* ")
+
+    if [ -n "$max_heap" ]; then
+        JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-Xmx[^ ]*/${max_heap} /")
+    fi
+    if [ -n "$initial_heap" ]; then
+        JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-Xms[^ ]* /${initial_heap} /")
+    fi
+}
+
+# Returns a set of options that are not supported by the current jvm.  The idea
+# is that java-default-options always configures settings for the latest jvm.
+# That said, it is possible that the configuration won't map to previous
+# versions of the jvm.  In those cases, it might be better to have different
+# implementations of java-default-options for each version of the jvm (e.g. a
+# private implementation that is sourced by java-default-options based on the
+# jvm version).  This would allow for the defaults to be tuned for the version
+# of the jvm being used.
+unsupported_options() {
+    if [[ $($JAVA_HOME/bin/java -version 2>&1 | awk -F "\"" '/version/{ print $2}') == *"1.7"* ]]; then
+        echo "(-XX:NativeMemoryTracking=[^ ]*|-XX:+PrintGCDateStamps|-XX:+UnlockDiagnosticVMOptions|-XX:CICompilerCount=[^ ]*|-XX:GCTimeRatio=[^ ]*|-XX:MaxMetaspaceSize=[^ ]*|-XX:AdaptiveSizePolicyWeight=[^ ]*)"
+    else
+        echo "(--XX:MaxPermSize=[^ ]*)"
+    fi
+}
+
+# Merge default java options into the passed argument
+adjust_java_options() {
+    local options="$@"
+    local remove_xms
+    local java_scripts_dir="/opt/run-java"
+    # nuke any hard-coded memory settings.  java-default-options won't add these
+    # if they're already specified
+    JAVA_OPTS="$(echo $JAVA_OPTS| sed -re 's/(-Xmx[^ ]*|-Xms[^ ]*)//g')"
+    local java_options=$(source "${java_scripts_dir}/java-default-options")
+    local unsupported="$(unsupported_options)"
+    for option in $java_options; do
+        if [[ ${option} == "-Xmx"* ]]; then
+            if [[ "$options" == *"-Xmx"* ]]; then
+                options=$(echo $options | sed -e "s/-Xmx[^ ]*/${option}/")
+            else
+                options="${options} ${option}"
+            fi
+            if [ "x$remove_xms" == "x" ]; then
+                remove_xms=1
+            fi
+        elif [[ ${option} == "-Xms"* ]]; then
+            if [[ "$options" == *"-Xms"* ]]; then
+                options=$(echo $options | sed -e "s/-Xms[^ ]*/${option}/")
+            else
+                options="${options} ${option}"
+            fi
+            remove_xms=0
+        elif $(echo "$options" | grep -Eq -- "${option%=*}(=[^ ]*)?(\s|$)") ; then
+            options=$(echo $options | sed -re "s@${option%=*}(=[^ ]*)?(\s|$)@${option}\2@")
+        else
+            options="${options} ${option}"
+        fi
+    done
+
+    if [[ "x$remove_xms" == "x1" ]]; then
+        options=$(echo $options | sed -e "s/-Xms[^ ]*/ /")
+    fi
+
+    options=$(echo "${options}"| sed -re "s@${unsupported}(\s)?@@g")
+    echo "${options}"
+}

--- a/wildfly-modules/dynamic-resources/install.sh
+++ b/wildfly-modules/dynamic-resources/install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+SCRIPT_DIR=$(dirname $0)
+
+# Add jboss user to root group
+usermod -g root -G jboss jboss
+
+mkdir -p /usr/local/dynamic-resources
+cp -p $SCRIPT_DIR/dynamic_resources.sh /usr/local/dynamic-resources/
+
+chown -R jboss:root /usr/local/dynamic-resources/
+chmod -R g+rwX $dir /usr/local/dynamic-resources/

--- a/wildfly-modules/dynamic-resources/module.yaml
+++ b/wildfly-modules/dynamic-resources/module.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+name: dynamic-resources
+version: '1.0'
+description: Legacy dynamic-resources script package.
+modules:
+  install:
+  - name: jboss.container.java.jvm.bash
+execute:
+- script: install.sh
+envs:
+    - name: "INITIAL_HEAP_PERCENT"
+      example: 0.5
+      description: Deprecated. See JAVA_INITIAL_MEM_RATIO.
+    - name: "CONTAINER_HEAP_PERCENT"
+      example: 0.5
+      description: Deprecated. See JAVA_MAX_MEM_RATIO.

--- a/wildfly-runtime-image/image.yaml
+++ b/wildfly-runtime-image/image.yaml
@@ -34,7 +34,7 @@ modules:
           - name: openjdk
             git:
               url: https://github.com/jboss-container-images/openjdk
-              ref: develop
+              ref: openjdk-containers-1.11
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules

--- a/wildfly-runtime-image/image.yaml
+++ b/wildfly-runtime-image/image.yaml
@@ -31,18 +31,21 @@ ports:
     - value: 8080
 modules:
       repositories:
-          - name: cct_module
+          - name: openjdk
             git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.45.1
+              url: https://github.com/jboss-container-images/openjdk
+              ref: develop
           - name: wildfly-cekit-modules
             git:
               url: https://github.com/wildfly/wildfly-cekit-modules
               ref: v2
+          - name: wildfly-modules
+            path: ../wildfly-modules
       install:
           - name: jboss.container.util.pkg-update
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: jboss.container.util.nss-wrapper
           - name: dynamic-resources
           - name: jboss.container.wildfly.run
 


### PR DESCRIPTION
This PR will be good to merge once:
* https://github.com/jboss-container-images/openjdk/pull/263 is merged in openjdk repository.
* We need to agree with openjdk team on how we can put in place a proper dependency (tagging, release, compatibility, ...).