### PR TITLE
[Master] Upgrade some test apps to use war maven plugin 3.3.2 to compile with JDK17, required by v2 tests.

### DIFF
--- a/test/test-app-advanced-extensions/pom.xml
+++ b/test/test-app-advanced-extensions/pom.xml
@@ -89,7 +89,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.3</version>
+                        <version>3.3.2</version>
                         <configuration>
                             <failOnMissingWebXml>false</failOnMissingWebXml>
                             <outputDirectory>target</outputDirectory>

--- a/test/test-app-custom/pom.xml
+++ b/test/test-app-custom/pom.xml
@@ -89,7 +89,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
-                        <version>2.3</version>
+                        <version>3.3.2</version>
                         <configuration>
                             <failOnMissingWebXml>false</failOnMissingWebXml>
                             <outputDirectory>target</outputDirectory>

--- a/test/test-app-web-security/pom.xml
+++ b/test/test-app-web-security/pom.xml
@@ -36,7 +36,7 @@
           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.3.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <outputDirectory>target</outputDirectory>

--- a/test/test-app/pom.xml
+++ b/test/test-app/pom.xml
@@ -36,7 +36,7 @@
           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.3.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <outputDirectory>target</outputDirectory>


### PR DESCRIPTION
We have some v1 tests that are part of the v2 test suite, these tests require the version of the War Maven plugin to be bumped in order to work also with JDK17 (JDK17 images for V2 are in progress).
