### PR TITLE
add properties for maven-compiler-plugin

### DIFF
--- a/examples/docker-build/pom.xml
+++ b/examples/docker-build/pom.xml
@@ -9,6 +9,8 @@
     <name>SampleApp</name>
   
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.jakartaee-api.version>8.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>


### PR DESCRIPTION
Fix below compilation error while building `example/docker-build `
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.

```