### PR TITLE
Fix ungroupified APIs in imagestreams and templates

### DIFF
--- a/imagestreams/wildfly-centos7.json
+++ b/imagestreams/wildfly-centos7.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/wildfly-runtime-centos7.json
+++ b/imagestreams/wildfly-runtime-centos7.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/templates/wildfly-builder-imagestream.yml
+++ b/templates/wildfly-builder-imagestream.yml
@@ -1,6 +1,6 @@
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: wildfly
   annotations:

--- a/templates/wildfly-runtime-imagestream.yml
+++ b/templates/wildfly-runtime-imagestream.yml
@@ -1,6 +1,6 @@
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: wildfly-runtime
 spec:

--- a/templates/wildfly-s2i-chained-build-template.yml
+++ b/templates/wildfly-s2i-chained-build-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: wildfly-s2i-chained-build-template


### PR DESCRIPTION
Such usage was deprecated in OpenShift 4.7 and will be removed in 4.11.
