### PR TITLE
Upgrade features to use WF 27 Alpha1 and cloud FP 2.0.0.Alpha1

### DIFF
--- a/wildfly-builder-image/tests/features/keycloak.feature
+++ b/wildfly-builder-image/tests/features/keycloak.feature
@@ -1,3 +1,5 @@
+#Keycloak tests can't be run starting WF27, missing some JBoss modules.
+@ignore
 @wildfly/wildfly-s2i-jdk17
 @wildfly/wildfly-s2i-jdk11
 Feature: Keycloak legacy tests

--- a/wildfly-builder-image/tests/features/legacy-elytron.feature
+++ b/wildfly-builder-image/tests/features/legacy-elytron.feature
@@ -6,7 +6,7 @@ Scenario: Build elytron app
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-web-security with env and true using legacy-s2i-images
        | variable                   | value       |
        | GALLEON_PROVISION_LAYERS | datasources-web-server |
-       | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+       | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
      Then container log should contain WFLYSRV0025
 
  Scenario: check Elytron configuration with elytron core realms security domain fail

--- a/wildfly-builder-image/tests/features/legacy-s2i.feature
+++ b/wildfly-builder-image/tests/features/legacy-s2i.feature
@@ -17,7 +17,7 @@ Scenario: Test preconfigure.sh
       | variable                             | value         |
       | TEST_EXTENSION_PRE_ADD_PROPERTY      | foo           |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served
@@ -31,12 +31,12 @@ Scenario: Test preconfigure.sh
     Given failing s2i build http://github.com/openshift/openshift-jee-sample from . using master
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS             | foo |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
 
   Scenario: Test default cloud config
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
      | GALLEON_PROVISION_LAYERS | cloud-default-config |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
@@ -48,7 +48,7 @@ Scenario: Test preconfigure.sh
   Scenario: Test cloud-server, exclude jaxrs
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
     | GALLEON_PROVISION_LAYERS             | cloud-server,-jaxrs  |
     Then container log should contain WFLYSRV0025
     And check that page is served
@@ -62,7 +62,7 @@ Scenario: Test preconfigure.sh
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:26.1.1.Final, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:2.0.0.Alpha1 |
    Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served
@@ -75,7 +75,7 @@ Scenario: Test external driver created during s2i.
       | variable                     | value                                                       |
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
   Then container log should contain WFLYSRV0025
     And check that page is served
       | property | value |
@@ -92,7 +92,7 @@ Scenario: Test external driver created during s2i.
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | DISABLE_BOOT_SCRIPT_INVOKER  | true |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
    Then container log should contain Configuring the server using embedded server
     Then container log should contain WFLYSRV0025
     And check that page is served
@@ -108,7 +108,7 @@ Scenario: Test external driver created during s2i.
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-binary with env and True using legacy-s2i-images
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS | jaxrs-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "app.war"
     And check that page is served

--- a/wildfly-builder-image/tests/features/messaging.feature
+++ b/wildfly-builder-image/tests/features/messaging.feature
@@ -6,7 +6,7 @@ Scenario: Configure amq7 remote broker
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and true using legacy-s2i-images
     | variable              | value                                   |
     | GALLEON_PROVISION_LAYERS             | cloud-server  |
-    | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:26.1.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+    | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1, org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
     | MQ_SERVICE_PREFIX_MAPPING           | wf-app-amq7=TEST |
     | WF_APP_AMQ_TCP_SERVICE_HOST      | 127.0.0.1 |
     | WF_APP_AMQ_TCP_SERVICE_PORT       | 5678 |

--- a/wildfly-builder-image/tests/features/oidc.feature
+++ b/wildfly-builder-image/tests/features/oidc.feature
@@ -25,7 +25,7 @@ Feature: OIDC tests
      Given s2i build http://github.com/wildfly/wildfly-s2i from test/test-app-elytron-oidc-client-legacy with env and True using main
        | variable               | value                                            |
        | GALLEON_PROVISION_LAYERS | cloud-server,elytron-oidc-client |
-       | GALLEON_PROVISION_FEATURE_PACKS|org.wildfly:wildfly-galleon-pack:26.1.1.Final,org.wildfly.cloud:wildfly-cloud-galleon-pack:1.1.2.Final |
+       | GALLEON_PROVISION_FEATURE_PACKS|org.wildfly:wildfly-galleon-pack:27.0.0.Alpha1,org.wildfly.cloud:wildfly-cloud-galleon-pack:2.0.0.Alpha1 |
 
   Scenario: Check oidc subsystem configuration, legacy.
      Given XML namespaces


### PR DESCRIPTION
* Upgrade behave scenarii
* Disable keycloak tests that can't be run with WF 27, will resurrect when SAML adapter is available.