### PR TITLE
A remote jms broker example using embedded-activemq Galleon layer

### DIFF
--- a/examples/jms-broker/README.md
+++ b/examples/jms-broker/README.md
@@ -1,0 +1,142 @@
+# WildFly embedded broker used as a remote broker
+
+In this example we are deploying 3 WildFly applications on OpenShift:
+
+* A broker configured with a persistent storage to store not delivered messages.
+* A jms message provider. A servlet that sends messages to a queue.
+* A jms consumer. An MDB EJB that consumes messages.
+
+WARNING: You can't scale the JMS Broker deployment beyond 1. To be able to scale the broker, clustering should be configured at the broker level. This is outside the scope of this example. 
+
+The builder and runtime images are running JDK11.
+
+# WildFly Maven plugin configuration
+High level view of the WildFly Maven plugin configuration
+
+## Galleon feature-packs
+
+* `org.wildfly:wildfly-galleon-pack`
+* `org.wildfly.cloud:wildfly-cloud-galleon-pack`
+
+## Galleon layers
+
+* `cloud-server`, for the producer and consumer applications.
+* `core-server`, for the jms broker.
+* `ejb`, for the mdb consumer.
+* `embedded-activemq`, for the jms broker.
+
+## CLI scripts
+WildFly CLI scripts executed at packaging time
+
+CLI scripts are run in order to fine tune the 3 servers:
+
+* `broker`: To create HELLOWORLDMDBTopic and HELLOWORLDMDBQueue, disable security and configure journal path to reference persistent volumes.
+* `producer`: To create external topic and queue, configure socket binding to the remote broker, pooled connection factory and http-connector.
+* `mdb-consumer`: To create external topic and queue, configure socket binding to the remote broker, pooled connection factory and http-connector.
+
+NB: In order to adapt the configuration to the execution context, the expression `${env.BROKER_HOST}` 
+is set in the producer and mdb-consumer socket-binding `host` attribute value. The env variable is set in the WildFly Helm chart yaml file.
+
+## Extra content
+Extra content packaged inside the provisioned servers
+
+* None
+
+# Openshift build and deployment
+Technologies required to build and deploy this example
+
+* Helm chart for WildFly `wildfly/wildfly`. Minimal version `2.1.0`.
+
+# WildFly image API
+Environment variables from the [WildFly image API](https://github.com/wildfly/wildfly-cekit-modules/blob/main/jboss/container/wildfly/run/api/module.yaml) that must be set in the OpenShift deployment environment
+
+* None
+
+# WildFly cloud feature-pack added features
+
+* The remote connection factory is configured with `reconnect-attempts=-1`, allowing the clients to reconnect when the broker is down. 
+
+# Pre-requisites
+
+* You are logged into an OpenShift cluster and have `oc` command in your path
+
+* You have installed Helm. Please refer to [Installing Helm page](https://helm.sh/docs/intro/install/) to install Helm in your environment
+
+* You have installed the repository for the Helm charts for WildFly
+
+ ```
+helm repo add wildfly https://docs.wildfly.org/wildfly-charts/
+```
+----
+**NOTE**
+
+If you have already installed the Helm Charts for WildFly, make sure to update your repository to the latest version.
+
+```
+helm repo update
+```
+----
+
+# Example steps
+
+1. Create the persistent volume.
+
+```
+oc create -f broker/jms-volume-claim.yaml
+```
+
+2. Deploy the broker using WildFly Helm charts
+
+```
+helm install jms-broker -f broker/helm.yaml wildfly/wildfly
+```
+
+3. Deploy the producer using WildFly Helm charts
+
+```
+helm install jms-producer -f producer/helm.yaml wildfly/wildfly
+```
+
+4. Deploy the consumer using WildFly Helm charts
+
+```
+helm install mdb-consumer -f mdb-consumer/helm.yaml wildfly/wildfly
+```
+
+Wait for the pods to be ready. It can takes some minutes for the images to be built and deployed.
+You can check the status of the pods by calling: `oc get pods -w`.
+
+
+5. Produces messages
+
+`curl https://$(oc get route jms-producer --template='{{ .spec.host }}')/HelloWorldMDBServletClient`
+
+Check the logs of the mdb-consumer, you will see the traces of the received messages.
+
+# Broker failure scenario, messages are persisted
+
+1. Scale down the mdb-consumer
+
+`oc scale --replicas=0 deployments mdb-consumer`
+
+2. Produces messages
+
+`curl https://$(oc get route jms-producer --template='{{ .spec.host }}')/HelloWorldMDBServletClient`
+
+These messages are persisted, waiting for a consumer to come online.
+
+3. Scale down the broker, emulates a failure.
+
+`oc scale --replicas=0 deployments jms-broker`
+
+4. Scale up the broker
+
+`oc scale --replicas=1 deployments jms-broker`
+
+WARNING: You can't scale the JMS Broker deployment beyond 1. To be able to scale the broker, clustering should be configured at the broker level. This is outside the scope of this example. 
+
+5. Scale up the mdb-consumer
+
+`oc scale --replicas=1 deployments mdb-consumer`
+
+Once the pod is ready, you will notice in the log that the messages are getting delivered.

--- a/examples/jms-broker/broker/helm.yaml
+++ b/examples/jms-broker/broker/helm.yaml
@@ -1,0 +1,14 @@
+build:
+  uri: https://github.com/wildfly/wildfly-s2i
+  contextDir: examples/jms-broker/broker
+  ref: main
+deploy:
+  replicas: 1
+  volumes:
+      - name: jms-journal
+        persistentVolumeClaim:
+          claimName: jms-journal
+  volumeMounts:
+        - mountPath: "/tmp/jms-journal"
+          name: jms-journal
+    

--- a/examples/jms-broker/broker/jms-volume-claim.yaml
+++ b/examples/jms-broker/broker/jms-volume-claim.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jms-journal
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: gp2
+  
+

--- a/examples/jms-broker/broker/jms.cli
+++ b/examples/jms-broker/broker/jms.cli
@@ -1,0 +1,7 @@
+/subsystem=messaging-activemq/server=default/jms-topic=HELLOWORLDMDBTopic:add(entries=[java:jboss/exported/jms/topic/HELLOWORLDMDBTopic])
+/subsystem=messaging-activemq/server=default/jms-queue=HELLOWORLDMDBQueue:add(entries=[java:jboss/exported/jms/queue/HELLOWORLDMDBQueue])
+/subsystem=messaging-activemq/server=default:write-attribute(name=security-enabled,value=false)
+/subsystem=messaging-activemq/server=default/path=bindings-directory:write-attribute(name=path,value=/tmp/jms-journal/bindings)
+/subsystem=messaging-activemq/server=default/path=journal-directory:write-attribute(name=path,value=/tmp/jms-journal/journal)
+/subsystem=messaging-activemq/server=default/path=large-messages-directory:write-attribute(name=path,value=/tmp/jms-journal/largemessages)
+/subsystem=messaging-activemq/server=default/path=paging-directory:write-attribute(name=path,value=/tmp/jms-journal/paging)

--- a/examples/jms-broker/broker/pom.xml
+++ b/examples/jms-broker/broker/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2022, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>SampleApp</groupId>
+    <artifactId>SampleApp</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0</version>
+    <name>SampleApp</name>
+  
+    <properties>
+        <plugin.fork.embedded>true</plugin.fork.embedded>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <jakarta.jakartaee-api.version>9.1.0</jakarta.jakartaee-api.version>
+        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
+        <version.wildfly>27.0.0.Alpha4</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>2.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.0.0.Beta3</version.wildfly.plugin>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakarta.jakartaee-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.maven.war.plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.plugin}</version>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                        </feature-pack>
+                        <feature-pack>
+                            <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>core-server</layer>
+                        <layer>embedded-activemq</layer>
+                    </layers>
+                    <packaging-scripts>
+                        <cli-session>
+                            <scripts>
+                                <script>jms.cli</script>
+                            </scripts>
+                        </cli-session>
+                    </packaging-scripts>
+                    <galleon-options>
+                        <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                    </galleon-options>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/jms-broker/mdb-consumer/helm.yaml
+++ b/examples/jms-broker/mdb-consumer/helm.yaml
@@ -1,0 +1,10 @@
+build:
+  uri: https://github.com/wildfly/wildfly-s2i
+  contextDir: examples/jms-broker/mdb-consumer
+  ref: main
+deploy:
+  replicas: 1
+  env:
+    - name: BROKER_HOST
+      value: "jms-broker"
+    

--- a/examples/jms-broker/mdb-consumer/jms.cli
+++ b/examples/jms-broker/mdb-consumer/jms.cli
@@ -1,0 +1,7 @@
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=messaging:add(host=${env.BROKER_HOST},port=8080)
+/subsystem=messaging-activemq/http-connector=remote-broker:add(socket-binding=messaging,endpoint=http-acceptor)
+/subsystem=messaging-activemq/pooled-connection-factory=wf-ra-remote:add(entries=["java:/JmsXA","java:/RemoteJmsXA", "java:jboss/RemoteJmsXA", "java:/wf-broker/ConnectionFactory"], connectors=[remote-broker], transaction=xa)
+/subsystem=messaging-activemq/external-jms-topic=HELLOWORLDMDBTopic:add(entries=[java:/HELLOWORLDMDBTopic])
+/subsystem=messaging-activemq/external-jms-queue=HELLOWORLDMDBQueue:add(entries=[java:/HELLOWORLDMDBQueue])
+/subsystem=ee/service=default-bindings:write-attribute(name=jms-connection-factory, value="java:/wf-broker/ConnectionFactory")
+/subsystem=ejb3:write-attribute(name=default-resource-adapter-name, value=wf-ra-remote.rar)

--- a/examples/jms-broker/mdb-consumer/pom.xml
+++ b/examples/jms-broker/mdb-consumer/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2022, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>SampleApp</groupId>
+    <artifactId>SampleApp</artifactId>
+    <packaging>war</packaging>
+    <version>1.0</version>
+    <name>SampleApp</name>
+  
+    <properties>
+        <plugin.fork.embedded>true</plugin.fork.embedded>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <jakarta.jakartaee-api.version>9.1.0</jakarta.jakartaee-api.version>
+        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
+        <version.wildfly>27.0.0.Alpha4</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>2.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.0.0.Beta3</version.wildfly.plugin>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakarta.jakartaee-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>mdb-consumer</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.maven.war.plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.plugin}</version>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                        </feature-pack>
+                        <feature-pack>
+                            <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>cloud-server</layer>
+                        <layer>ejb</layer>
+                    </layers>
+                    <packaging-scripts>
+                        <cli-session>
+                            <scripts>
+                                <script>jms.cli</script>
+                            </scripts>
+                        </cli-session>
+                    </packaging-scripts>
+                    <galleon-options>
+                        <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                    </galleon-options>
+                    <runtime-name>ROOT.war</runtime-name>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/jms-broker/mdb-consumer/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
+++ b/examples/jms-broker/mdb-consumer/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.mdb;
+
+import java.util.logging.Logger;
+import jakarta.ejb.ActivationConfigProperty;
+import jakarta.ejb.MessageDriven;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+import jakarta.jms.TextMessage;
+
+/**
+ * <p>
+ * A simple Message Driven Bean that asynchronously receives and processes the messages that are sent to the queue.
+ * </p>
+ *
+ * @author Serge Pagop (spagop@redhat.com)
+ */
+@MessageDriven(name = "HelloWorldQueueMDB", activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "HELLOWORLDMDBQueue"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "jakarta.jms.Queue"),
+        @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge")})
+public class HelloWorldQueueMDB implements MessageListener {
+
+    private static final Logger LOGGER = Logger.getLogger(HelloWorldQueueMDB.class.toString());
+
+    /**
+     * @see MessageListener#onMessage(Message)
+     */
+    public void onMessage(Message rcvMessage) {
+        TextMessage msg = null;
+        try {
+            if (rcvMessage instanceof TextMessage) {
+                msg = (TextMessage) rcvMessage;
+                LOGGER.info("Received Message from queue: " + msg.getText());
+            } else {
+                LOGGER.warning("Message of wrong type: " + rcvMessage.getClass().getName());
+            }
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/jms-broker/mdb-consumer/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldTopicMDB.java
+++ b/examples/jms-broker/mdb-consumer/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldTopicMDB.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.mdb;
+
+import java.util.logging.Logger;
+import jakarta.ejb.ActivationConfigProperty;
+import jakarta.ejb.MessageDriven;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+import jakarta.jms.TextMessage;
+
+/**
+ * <p>
+ * A simple Message Driven Bean that asynchronously receives and processes the messages that are sent to the topic.
+ * </p>
+ *
+ * @author Serge Pagop (spagop@redhat.com)
+ */
+@MessageDriven(name = "HelloWorldQTopicMDB", activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "HELLOWORLDMDBTopic"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "jakarta.jms.Topic"),
+        @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge")})
+public class HelloWorldTopicMDB implements MessageListener {
+
+    private static final Logger LOGGER = Logger.getLogger(HelloWorldTopicMDB.class.toString());
+
+    /**
+     * @see MessageListener#onMessage(Message)
+     */
+    public void onMessage(Message rcvMessage) {
+        TextMessage msg = null;
+        try {
+            if (rcvMessage instanceof TextMessage) {
+                msg = (TextMessage) rcvMessage;
+                LOGGER.info("Received Message from topic: " + msg.getText());
+            } else {
+                LOGGER.warning("Message of wrong type: " + rcvMessage.getClass().getName());
+            }
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/jms-broker/mdb-consumer/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/jms-broker/mdb-consumer/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      https://jakarta.ee/xml/ns/jakartaee
+      https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+    bean-discovery-mode="all">
+</beans>

--- a/examples/jms-broker/producer/helm.yaml
+++ b/examples/jms-broker/producer/helm.yaml
@@ -1,0 +1,9 @@
+build:
+  uri: https://github.com/wildfly/wildfly-s2i
+  contextDir: examples/jms-broker/producer
+  ref: main
+deploy:
+  replicas: 1
+  env:
+    - name: BROKER_HOST
+      value: "jms-broker"

--- a/examples/jms-broker/producer/jms.cli
+++ b/examples/jms-broker/producer/jms.cli
@@ -1,0 +1,6 @@
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=messaging:add(host=${env.BROKER_HOST},port=8080)
+/subsystem=messaging-activemq/http-connector=remote-broker:add(socket-binding=messaging,endpoint=http-acceptor)
+/subsystem=messaging-activemq/pooled-connection-factory=wf-ra-remote:add(entries=["java:/JmsXA","java:/RemoteJmsXA", "java:jboss/RemoteJmsXA", "java:/wf-broker/ConnectionFactory"], connectors=[remote-broker], transaction=xa)
+/subsystem=messaging-activemq/external-jms-topic=HELLOWORLDMDBTopic:add(entries=[java:/HELLOWORLDMDBTopic])
+/subsystem=messaging-activemq/external-jms-queue=HELLOWORLDMDBQueue:add(entries=[java:/HELLOWORLDMDBQueue])
+/subsystem=ee/service=default-bindings:write-attribute(name=jms-connection-factory, value="java:/wf-broker/ConnectionFactory")

--- a/examples/jms-broker/producer/pom.xml
+++ b/examples/jms-broker/producer/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2022, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>SampleApp</groupId>
+    <artifactId>SampleApp</artifactId>
+    <packaging>war</packaging>
+    <version>1.0</version>
+    <name>SampleApp</name>
+  
+    <properties>
+        <plugin.fork.embedded>true</plugin.fork.embedded>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <jakarta.jakartaee-api.version>9.1.0</jakarta.jakartaee-api.version>
+        <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
+        <version.wildfly>27.0.0.Alpha4</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>2.0.0.Alpha4</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.0.0.Beta3</version.wildfly.plugin>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>${jakarta.jakartaee-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>jms-producer</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.maven.war.plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.plugin}</version>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                        </feature-pack>
+                        <feature-pack>
+                            <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>cloud-server</layer>
+                    </layers>
+                    <packaging-scripts>
+                        <cli-session>
+                            <scripts>
+                                <script>jms.cli</script>
+                            </scripts>
+                        </cli-session>
+                    </packaging-scripts>
+                    <galleon-options>
+                        <jboss-fork-embedded>${plugin.fork.embedded}</jboss-fork-embedded>
+                    </galleon-options>
+                    <runtime-name>ROOT.war</runtime-name>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/jms-broker/producer/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
+++ b/examples/jms-broker/producer/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * <p>
+ * A simple servlet 3 as client that sends several messages to a queue or a topic.
+ * </p>
+ *
+ * <p>
+ * The servlet is registered and mapped to /HelloWorldMDBServletClient using the {@linkplain WebServlet
+ * @HttpServlet}.
+ * </p>
+ *
+ * @author Serge Pagop (spagop@redhat.com)
+ *
+ */
+@WebServlet("/HelloWorldMDBServletClient")
+public class HelloWorldMDBServletClient extends HttpServlet {
+
+    private static final long serialVersionUID = -8314035702649252239L;
+
+    private static final int MSG_COUNT = 5;
+
+    @Inject
+    private JMSContext context;
+
+    @Resource(lookup = "java:/HELLOWORLDMDBQueue")
+    private Queue queue;
+
+    @Resource(lookup = "java:/HELLOWORLDMDBTopic")
+    private Topic topic;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/html");
+        PrintWriter out = resp.getWriter();
+        out.write("<h1>Quickstart: Example demonstrates the use of <strong>JMS 2.0</strong> and <strong>EJB 3.2 Message-Driven Bean</strong> in JBoss EAP.</h1>");
+        try {
+            boolean useTopic = req.getParameterMap().keySet().contains("topic");
+            final Destination destination = useTopic ? topic : queue;
+
+            out.write("<p>Sending messages to <em>" + destination + "</em></p>");
+            out.write("<h2>The following messages will be sent to the destination:</h2>");
+            for (int i = 0; i < MSG_COUNT; i++) {
+                String text = "This is message " + (i + 1);
+                context.createProducer().send(destination, text);
+                out.write("Message (" + i + "): " + text + "</br>");
+            }
+            out.write("<p><i>Go to your JBoss EAP server console or server log to see the result of messages processing.</i></p>");
+        } finally {
+            if (out != null) {
+                out.close();
+            }
+        }
+    }
+
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        doGet(req, resp);
+    }
+}

--- a/examples/jms-broker/producer/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/jms-broker/producer/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      https://jakarta.ee/xml/ns/jakartaee
+      https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+    bean-discovery-mode="all">
+</beans>

--- a/examples/jms-broker/producer/src/main/webapp/index.html
+++ b/examples/jms-broker/producer/src/main/webapp/index.html
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Plain HTML page that kicks us into the app -->
+
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; URL=HelloWorldMDBServletClient">
+</head>
+</html>


### PR DESCRIPTION
An example composed of 3 deployments to highlight a possible usage of the embedded-activemq galleon layer to setup a remote broker with message persistence enabled.
