### PR TITLE
Upgrade test features and examples to WF 29 Final, cloud 4, datasources 5

### DIFF
--- a/examples/cloud-default-config/pom.xml
+++ b/examples/cloud-default-config/pom.xml
@@ -12,11 +12,11 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.datasources.galleon.pack>4.0.0.Final</version.wildfly.datasources.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.datasources.galleon.pack>5.0.0.Final</version.wildfly.datasources.galleon.pack>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
     </properties>
 

--- a/examples/docker-build/pom.xml
+++ b/examples/docker-build/pom.xml
@@ -14,8 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
     </properties>
     
     <dependencies>

--- a/examples/elytron-oidc-client-auto-reg/pom.xml
+++ b/examples/elytron-oidc-client-auto-reg/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
     </properties>
 

--- a/examples/elytron-oidc-client/pom.xml
+++ b/examples/elytron-oidc-client/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
     </properties>
 

--- a/examples/jms-broker/broker/pom.xml
+++ b/examples/jms-broker/broker/pom.xml
@@ -33,9 +33,9 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
     </properties>
 
     <dependencies>

--- a/examples/jms-broker/mdb-consumer/pom.xml
+++ b/examples/jms-broker/mdb-consumer/pom.xml
@@ -33,9 +33,9 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
     </properties>
 
     <dependencies>

--- a/examples/jms-broker/producer/pom.xml
+++ b/examples/jms-broker/producer/pom.xml
@@ -33,9 +33,9 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
     </properties>
 
     <dependencies>

--- a/examples/jsf-ejb-jpa/pom.xml
+++ b/examples/jsf-ejb-jpa/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
     </properties>
 

--- a/examples/postgresql-multiple-datasources/pom.xml
+++ b/examples/postgresql-multiple-datasources/pom.xml
@@ -13,10 +13,10 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.datasources.galleon.pack>4.0.0.Final</version.wildfly.datasources.galleon.pack>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.datasources.galleon.pack>5.0.0.Final</version.wildfly.datasources.galleon.pack>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
     </properties>
 

--- a/examples/postgresql-preview/pom.xml
+++ b/examples/postgresql-preview/pom.xml
@@ -13,10 +13,10 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.datasources.galleon.pack>3.0.0.Final</version.wildfly.datasources.galleon.pack>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.datasources.galleon.pack>5.0.0.Final</version.wildfly.datasources.galleon.pack>
     </properties>
 
      <dependencies>

--- a/examples/postgresql/pom.xml
+++ b/examples/postgresql/pom.xml
@@ -13,10 +13,10 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.datasources.galleon.pack>3.0.0.Final</version.wildfly.datasources.galleon.pack>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.datasources.galleon.pack>5.0.0.Final</version.wildfly.datasources.galleon.pack>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
     </properties>
 

--- a/examples/web-clustering/pom.xml
+++ b/examples/web-clustering/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
     </properties>
     <dependencies>

--- a/wildfly-builder-image/image.yaml
+++ b/wildfly-builder-image/image.yaml
@@ -70,6 +70,8 @@ packages:
           - jq
           - vim-minimal
           - unzip
+          # temporary until the dependency is fixed in openjdk modules
+          - tzdata-java
 run:
       user: 185
       cmd:

--- a/wildfly-builder-image/tests/features/legacy-elytron.feature
+++ b/wildfly-builder-image/tests/features/legacy-elytron.feature
@@ -5,7 +5,7 @@ Scenario: Build elytron app
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-web-security with env and true using legacy-s2i-images-ee-10-test-apps
        | variable                   | value       |
        | GALLEON_PROVISION_LAYERS | datasources-web-server |
-       | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+       | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
      Then container log should contain WFLYSRV0025
 
  Scenario: check Elytron configuration with elytron core realms security domain fail

--- a/wildfly-builder-image/tests/features/legacy-s2i.feature
+++ b/wildfly-builder-image/tests/features/legacy-s2i.feature
@@ -16,7 +16,7 @@ Scenario: Test preconfigure.sh
       | variable                             | value         |
       | TEST_EXTENSION_PRE_ADD_PROPERTY      | foo           |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served
@@ -31,12 +31,12 @@ Scenario: Test preconfigure.sh
     Given failing s2i build http://github.com/openshift/openshift-jee-sample from . using master
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS             | foo |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
 
   Scenario: Test default cloud config
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
       | GALLEON_PROVISION_LAYERS | cloud-default-config |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
@@ -48,7 +48,7 @@ Scenario: Test preconfigure.sh
   Scenario: Test cloud-server, exclude jaxrs
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
       | GALLEON_PROVISION_LAYERS             | cloud-server,-jaxrs  |
     Then container log should contain WFLYSRV0025
     And check that page is served
@@ -62,7 +62,7 @@ Scenario: Test preconfigure.sh
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:29.0.0.Final, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:4.0.0.Final |
    Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served
@@ -75,7 +75,7 @@ Scenario: Test external driver created during s2i.
       | variable                     | value                                                       |
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
   Then container log should contain WFLYSRV0025
     And check that page is served
       | property | value |
@@ -90,7 +90,7 @@ Scenario: Test external driver created during s2i.
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | DISABLE_BOOT_SCRIPT_INVOKER  | true |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
    Then container log should contain Configuring the server using embedded server
     Then container log should contain WFLYSRV0025
     And check that page is served
@@ -104,7 +104,7 @@ Scenario: Test external driver created during s2i.
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-binary with env and True using legacy-s2i-images
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS | jaxrs-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "app.war"
     And check that page is served
@@ -117,7 +117,7 @@ Scenario: Test external driver created during s2i.
    | variable                 | value           |
    | MAVEN_S2I_ARTIFACT_DIRS | app1/target,app2/target |
    | GALLEON_PROVISION_LAYERS | cloud-server |
-   | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+   | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
    ### PLACEHOLDER FOR CLOUD CUSTOM TESTING ###
    Then container log should contain WFLYSRV0010: Deployed "App1.war"
    Then container log should contain WFLYSRV0010: Deployed "App2.war"

--- a/wildfly-builder-image/tests/features/messaging.feature
+++ b/wildfly-builder-image/tests/features/messaging.feature
@@ -5,7 +5,7 @@ Scenario: Configure amq7 remote broker
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and true using legacy-s2i-images
     | variable              | value                                   |
     | GALLEON_PROVISION_LAYERS             | cloud-server  |
-    | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Beta1, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+    | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:29.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
     | MQ_SERVICE_PREFIX_MAPPING           | wf-app-amq7=TEST |
     | WF_APP_AMQ_TCP_SERVICE_HOST      | 127.0.0.1 |
     | WF_APP_AMQ_TCP_SERVICE_PORT       | 5678 |

--- a/wildfly-builder-image/tests/features/oidc.feature
+++ b/wildfly-builder-image/tests/features/oidc.feature
@@ -24,7 +24,7 @@ Feature: OIDC tests
      Given s2i build http://github.com/wildfly/wildfly-s2i from test/test-app-elytron-oidc-client-legacy with env and True using main
        | variable               | value                                            |
        | GALLEON_PROVISION_LAYERS | cloud-server,elytron-oidc-client |
-       | GALLEON_PROVISION_FEATURE_PACKS|org.wildfly:wildfly-galleon-pack:29.0.0.Beta1,org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Beta1 |
+       | GALLEON_PROVISION_FEATURE_PACKS|org.wildfly:wildfly-galleon-pack:29.0.0.Final,org.wildfly.cloud:wildfly-cloud-galleon-pack:4.0.0.Final |
   Scenario: Check oidc subsystem configuration, legacy.
      Given XML namespaces
        | prefix | url                          |

--- a/wildfly-builders/pom.xml
+++ b/wildfly-builders/pom.xml
@@ -34,10 +34,10 @@
         </license>
     </licenses>
     <properties>
-        <version.wildfly>28.0.0.Final</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>3.0.0.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.datasources.galleon.pack>4.0.0.Final</version.wildfly.datasources.galleon.pack>
-        <version.wildfly.plugin>4.1.0.Beta6</version.wildfly.plugin>
+        <version.wildfly>29.0.0.Final</version.wildfly>
+        <version.wildfly.cloud.galleon.pack>4.0.0.Final</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.datasources.galleon.pack>5.0.0.Final</version.wildfly.datasources.galleon.pack>
+        <version.wildfly.plugin>4.2.0.Final</version.wildfly.plugin>
     </properties>
 
     <build>

--- a/wildfly-runtime-image/image.yaml
+++ b/wildfly-runtime-image/image.yaml
@@ -54,6 +54,9 @@ packages:
           - jq
           - vim-minimal
           - unzip
+          # temporarily until the dependency is fixed in openjdk modules
+          - tzdata-java
+
 
 run:
       user: 185


### PR DESCRIPTION
temporary add the tzdata-java package to fix issues with JDK 11 RPM.