### PR TITLE
docker-build example: export OPENSHIFT_IMAGE_REGISTRY variable

### DIFF
--- a/examples/docker-build/README.md
+++ b/examples/docker-build/README.md
@@ -118,7 +118,7 @@ export IMAGE=myapp:latest
 export OPENSHIFT_NS=$(oc project -q)
 oc registry login
 # Copy the route in the env variable OPENSHIFT_IMAGE_REGISTRY
-OPENSHIFT_IMAGE_REGISTRY=$(oc registry info)
+export OPENSHIFT_IMAGE_REGISTRY=$(oc registry info)
 docker login -u openshift -p $(oc whoami -t)  $OPENSHIFT_IMAGE_REGISTRY
 docker tag  $IMAGE $OPENSHIFT_IMAGE_REGISTRY/$OPENSHIFT_NS/$IMAGE
 docker push  $OPENSHIFT_IMAGE_REGISTRY/$OPENSHIFT_NS/$IMAGE


### PR DESCRIPTION
imho it would be better if this was exported. If someone uses this commands as a template to create a script  (as I did)   lack of this export may lead to bugs.