### PR TITLE
Update test applications to WildFly 40.0.1.Final

### DIFF
--- a/test/test-app-advanced-extensions/pom.xml
+++ b/test/test-app-advanced-extensions/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-clustering/pom.xml
+++ b/test/test-app-clustering/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-default-config/pom.xml
+++ b/test/test-app-default-config/pom.xml
@@ -34,7 +34,7 @@
         </license>
     </licenses>
     <properties>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-ejb/pom.xml
+++ b/test/test-app-ejb/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-elytron-oidc-client/pom.xml
+++ b/test/test-app-elytron-oidc-client/pom.xml
@@ -15,7 +15,7 @@
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-extension/pom.xml
+++ b/test/test-app-extension/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-extension2/pom.xml
+++ b/test/test-app-extension2/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-invalid/pom.xml
+++ b/test/test-app-invalid/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-jpa2lc/pom.xml
+++ b/test/test-app-jpa2lc/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-keycloak-saml/pom.xml
+++ b/test/test-app-keycloak-saml/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>

--- a/test/test-app-mdb/pom.xml
+++ b/test/test-app-mdb/pom.xml
@@ -33,7 +33,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-multi-deployments-invalid/pom.xml
+++ b/test/test-app-multi-deployments-invalid/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-multi-deployments-legacy/pom.xml
+++ b/test/test-app-multi-deployments-legacy/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-multi-deployments/pom.xml
+++ b/test/test-app-multi-deployments/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-multi-deployments2/pom.xml
+++ b/test/test-app-multi-deployments2/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-multi-deployments3/pom.xml
+++ b/test/test-app-multi-deployments3/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-postgres/pom.xml
+++ b/test/test-app-postgres/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.datasources.galleon.pack>11.4.0.Final</version.wildfly.datasources.galleon.pack>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>

--- a/test/test-app-postgresql-mysql/pom.xml
+++ b/test/test-app-postgresql-mysql/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.datasources.galleon.pack>11.4.0.Final</version.wildfly.datasources.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>

--- a/test/test-app-settings/pom.xml
+++ b/test/test-app-settings/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-slim/pom.xml
+++ b/test/test-app-slim/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app-stability-preview/pom.xml
+++ b/test/test-app-stability-preview/pom.xml
@@ -34,7 +34,7 @@
         </license>
     </licenses>
     <properties>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/test-app/pom.xml
+++ b/test/test-app/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.cloud.galleon.pack>9.2.3.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>

--- a/test/vanilla-wildfly/test-app-s2i-cli-scripts/pom.xml
+++ b/test/vanilla-wildfly/test-app-s2i-cli-scripts/pom.xml
@@ -9,7 +9,7 @@
     <name>SampleApp</name>
 
     <properties>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>
     <build>

--- a/test/vanilla-wildfly/test-app/pom.xml
+++ b/test/vanilla-wildfly/test-app/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jakarta.jakartaee-api.version>10.0.0</jakarta.jakartaee-api.version>
         <version.maven.war.plugin>3.3.2</version.maven.war.plugin>
-        <version.wildfly>40.0.0.Final</version.wildfly>
+        <version.wildfly>40.0.1.Final</version.wildfly>
         <version.wildfly.plugin>${env.PROVISIONING_MAVEN_PLUGIN_VERSION}</version.wildfly.plugin>
     </properties>
     


### PR DESCRIPTION
Upgrade WildFly feature-pack version from 40.0.0.Final to 40.0.1.Final in all test application pom.xml files to align with the latest WildFly release as specified in the wildfly-galleon-feature-packs repository.