### PR TITLE
Update behave feature tests to WildFly 40.0.1.Final

### DIFF
--- a/wildfly-builder-image/tests/features/legacy-elytron.feature
+++ b/wildfly-builder-image/tests/features/legacy-elytron.feature
@@ -5,7 +5,7 @@ Scenario: Build elytron app
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-web-security with env and true using legacy-s2i-images-ee-10-test-apps
        | variable                   | value       |
        | GALLEON_PROVISION_LAYERS | datasources-web-server |
-       | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+       | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
      Then container log should contain WFLYSRV0025
 
  Scenario: check Elytron configuration with elytron core realms security domain fail

--- a/wildfly-builder-image/tests/features/legacy-s2i.feature
+++ b/wildfly-builder-image/tests/features/legacy-s2i.feature
@@ -16,7 +16,7 @@ Scenario: Test preconfigure.sh
       | variable                             | value         |
       | TEST_EXTENSION_PRE_ADD_PROPERTY      | foo           |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served
@@ -31,12 +31,12 @@ Scenario: Test preconfigure.sh
     Given failing s2i build http://github.com/openshift/openshift-jee-sample from . using master
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS             | foo |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
 
   Scenario: Test default cloud config
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
       | GALLEON_PROVISION_LAYERS | cloud-default-config |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
@@ -48,7 +48,7 @@ Scenario: Test preconfigure.sh
   Scenario: Test cloud-server, exclude jaxrs
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
       | GALLEON_PROVISION_LAYERS             | cloud-server,-jaxrs  |
     Then container log should contain WFLYSRV0025
     And check that page is served
@@ -63,7 +63,7 @@ Scenario: Test external driver created during s2i.
       | variable                     | value                                                       |
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
   Then container log should contain WFLYSRV0025
     And check that page is served
       | property | value |
@@ -78,7 +78,7 @@ Scenario: Test external driver created during s2i.
       | ENV_FILES                    | /opt/server/standalone/configuration/datasources.env |
       | DISABLE_BOOT_SCRIPT_INVOKER  | true |
       | GALLEON_PROVISION_LAYERS             | cloud-server  |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
    Then container log should contain Configuring the server using embedded server
     Then container log should contain WFLYSRV0025
     And check that page is served
@@ -92,7 +92,7 @@ Scenario: Test external driver created during s2i.
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app-binary with env and True using legacy-s2i-images
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS | jaxrs-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
     Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "app.war"
     And check that page is served
@@ -105,7 +105,7 @@ Scenario: Test external driver created during s2i.
    | variable                 | value           |
    | MAVEN_S2I_ARTIFACT_DIRS | app1/target,app2/target |
    | GALLEON_PROVISION_LAYERS | cloud-server |
-   | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+   | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
    ### PLACEHOLDER FOR CLOUD CUSTOM TESTING ###
    Then container log should contain WFLYSRV0010: Deployed "App1.war"
    Then container log should contain WFLYSRV0010: Deployed "App2.war"
@@ -115,7 +115,7 @@ Scenario: Test external driver created during s2i.
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:40.0.0.Final, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:40.0.1.Final, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:9.2.3.Final |
    Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served

--- a/wildfly-builder-image/tests/features/messaging.feature
+++ b/wildfly-builder-image/tests/features/messaging.feature
@@ -5,7 +5,7 @@ Scenario: Configure amq7 remote broker
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and true using legacy-s2i-images
     | variable              | value                                   |
     | GALLEON_PROVISION_LAYERS             | cloud-server  |
-    | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.0.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+    | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-galleon-pack:40.0.1.Final, org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
     | MQ_SERVICE_PREFIX_MAPPING           | wf-app-amq7=TEST |
     | WF_APP_AMQ_TCP_SERVICE_HOST      | 127.0.0.1 |
     | WF_APP_AMQ_TCP_SERVICE_PORT       | 5678 |

--- a/wildfly-builder-image/tests/features/no-jdk11.feature
+++ b/wildfly-builder-image/tests/features/no-jdk11.feature
@@ -5,7 +5,7 @@ Feature: Wildfly Legacy s2i tests that can't run on JDK11
     Given s2i build https://github.com/wildfly/wildfly-s2i from test/test-app with env and True using legacy-s2i-images
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS | cloud-server |
-      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:40.0.0.Final, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:9.2.3.Final |
+      | GALLEON_PROVISION_FEATURE_PACKS | org.wildfly:wildfly-preview-feature-pack:40.0.1.Final, org.wildfly.cloud:wildfly-preview-cloud-galleon-pack:9.2.3.Final |
    Then container log should contain WFLYSRV0025
     And container log should contain WFLYSRV0010: Deployed "ROOT.war"
     And check that page is served

--- a/wildfly-builder-image/tests/features/oidc.feature
+++ b/wildfly-builder-image/tests/features/oidc.feature
@@ -24,7 +24,7 @@ Feature: OIDC tests
      Given s2i build http://github.com/wildfly/wildfly-s2i from test/test-app-elytron-oidc-client-legacy with env and True using main
        | variable               | value                                            |
        | GALLEON_PROVISION_LAYERS | cloud-server,elytron-oidc-client |
-       | GALLEON_PROVISION_FEATURE_PACKS|org.wildfly:wildfly-galleon-pack:40.0.0.Final,org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
+       | GALLEON_PROVISION_FEATURE_PACKS|org.wildfly:wildfly-galleon-pack:40.0.1.Final,org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.3.Final |
   Scenario: Check oidc subsystem configuration, legacy.
      Given XML namespaces
        | prefix | url                          |


### PR DESCRIPTION
Upgrade WildFly feature-pack versions from 40.0.0.Final to 40.0.1.Final in behave test feature files to align with the latest WildFly release.